### PR TITLE
[fix/#62]: 게시판 게시글 제목에만 a태그가 적용되는 문제 해결

### DIFF
--- a/src/entities/board/main/Board.tsx
+++ b/src/entities/board/main/Board.tsx
@@ -25,20 +25,20 @@ export const Board = ({
           {contents.length === 0 ? (
             <EmptyContent />
           ) : (
-            <ul className="divide-y-2">
+            <div className="divide-y-2">
               {contents.map((content, idx) => (
-                <li className="truncate py-2" key={content.contentId}>
+                <div key={content.contentId}>
                   <Link href={`/board/${boardId}/${content.contentId}`}>
-                    {content.title}{" "}
+                    <div className="truncate py-2">{content.title} </div>
                   </Link>
-                </li>
+                </div>
               ))}
               {emptyContents.map((_, idx) => (
-                <li className="py-2" key={idx}>
+                <div className="py-2" key={idx}>
                   　
-                </li>
+                </div>
               ))}
-            </ul>
+            </div>
           )}
         </Link>
       </div>


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호
#62 

📋 PR Checklist

- [x] 게시판 메인 화면에서 게시글 제목 부분에만 <a> 태그가 적용되는 문제 해결


📌 유의사항
✅ 테스트 결과
이전
![image](https://github.com/user-attachments/assets/07c63d68-ecb5-4ad0-b36e-90be9495ce32)

변경 후
![image](https://github.com/user-attachments/assets/d7353a2d-818f-4517-8b60-da9b6c62e245)

