### PR TITLE
[Feat/#64] 사진이 있는 게시글의 경우, 게시글 목록에서 첨부된 사진이 썸네일로 설정되게 기능 추가

### DIFF
--- a/src/entities/board/postList/PostList.tsx
+++ b/src/entities/board/postList/PostList.tsx
@@ -99,10 +99,7 @@ export const PostList = () => {
                     <div className="h-16 w-16 flex-shrink-0 sm:h-24 sm:w-24">
                       <Image
                         src={
-                          post.postAttachImage &&
-                          post.postAttachImage.match(
-                            /(.*?).(jpg|jpeg|png|gif|bmp)$/,
-                          )
+                          post.postAttachImage
                             ? post.postAttachImage
                             : "/images/post_default_thumbnail.png"
                         }

--- a/src/entities/board/postList/PostList.tsx
+++ b/src/entities/board/postList/PostList.tsx
@@ -98,11 +98,18 @@ export const PostList = () => {
                     </div>
                     <div className="h-16 w-16 flex-shrink-0 sm:h-24 sm:w-24">
                       <Image
-                        src="/images/post_default_thumbnail.png"
-                        alt="default_thumbnail"
+                        src={
+                          post.postAttachImage &&
+                          post.postAttachImage.match(
+                            /(.*?).(jpg|jpeg|png|gif|bmp)$/,
+                          )
+                            ? post.postAttachImage
+                            : "/images/post_default_thumbnail.png"
+                        }
+                        alt="post_thumbnail"
                         width={100}
                         height={100}
-                        className="object-cover"
+                        className="object-contain"
                       />
                     </div>
                   </div>

--- a/src/shared/@types/post.d.ts
+++ b/src/shared/@types/post.d.ts
@@ -57,6 +57,7 @@ declare namespace Post {
     isDeleted: boolean;
     isPostVote: boolean;
     isPostForm: boolean;
+    postAttachImage: "string" | null;
   }
 
   export interface PostDeleteDto {


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호
#64 
📋 PR Checklist

- [x] 사진이 첨부되어 있는 게시글의 경우, 게시글 목록에서 첨부된 사진이 썸네일로 설정되게 기능을 추가하였습니다.


📌 유의사항
✅ 테스트 결과

이전
![image](https://github.com/user-attachments/assets/a4bcbf4c-7c6e-4837-8455-8dca7d97e4ce)

기능 추가 후
![image](https://github.com/user-attachments/assets/fcc034e0-7a15-4176-a398-06276dac3db1)

