### PR TITLE
110 feat implement page routing for event notifications alarm settings

### DIFF
--- a/src/app/(causw)/occasion/apply/page.tsx
+++ b/src/app/(causw)/occasion/apply/page.tsx
@@ -1,0 +1,7 @@
+const OccasionApply = () => (
+    <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-col items-center justify-center text-xl font-bold">
+      경조사 신청 페이지
+    </div>
+  );
+  
+  export default OccasionApply;

--- a/src/app/(causw)/occasion/page.tsx
+++ b/src/app/(causw)/occasion/page.tsx
@@ -1,0 +1,7 @@
+const Occasion = () => (
+  <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-col items-center justify-center text-xl font-bold">
+    경조사 목록 페이지
+  </div>
+);
+
+export default Occasion;

--- a/src/app/(causw)/setting/occasion/page.tsx
+++ b/src/app/(causw)/setting/occasion/page.tsx
@@ -1,0 +1,7 @@
+const Occasion = () => (
+    <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-col items-center justify-center text-xl font-bold">
+      경조사 관리 페이지
+    </div>
+  );
+  
+  export default Occasion;

--- a/src/app/(causw)/setting/page.tsx
+++ b/src/app/(causw)/setting/page.tsx
@@ -7,8 +7,6 @@ import { UseTerms } from "@/entities/home/useTerms";
 const SettingsPage = () => {
   const {
     roles,
-    isStudent,
-    isProfessor,
     isAdmin,
     isPresidents,
     isVicePresidents,
@@ -54,31 +52,31 @@ const SettingsPage = () => {
       : [];
 
   const menuItems = {
-    계정: [
+    account: [
       { name: "개인정보 관리", link: "/setting/personal-info" },
       { name: "비밀번호 변경", link: "/setting/resetpassword" },
       { name: "로그아웃", link: "/auth/signin" },
       { name: "이용약관", link: "/setting/useterms" },
     ],
-    기록: [
+    records: [
       { name: "내가 쓴 글", link: "/setting/my/posts" },
       { name: "내가 쓴 댓글", link: "/setting/my/comments" },
       { name: "내가 찜한 글", link: "/setting/my/favorite" },
     ],
-    관리_동문회장: [{ name: "유저 관리", link: "/" }],
-    관리_관리자_학생회장_부학생회장: [
+    managementAlumniPresident: [{ name: "유저 관리", link: "/" }],
+    managementAdmin: [
       { name: "권한 관리", link: "/setting/management/role/president" },
       { name: "유저 관리", link: "/setting/management/user/admission" },
       { name: "학생회비 납부자 관리", link: "/setting/management/payer" },
       { name: "학적 상태 관리", link: "/setting/management/attendance/all" },
     ],
-    권한위임: [...roleItems, ...circleLeaderItems],
-    홈화면관리: [
+    delegation: [...roleItems, ...circleLeaderItems],
+    homeManagement: [
       { name: "이벤트 배너 공지 편집", link: "/setting/home/event" },
       { name: "캘린더 편집", link: "/setting/home/calendar" },
     ],
 
-    동아리관리: (circleId: string) => [
+    clubManagement: (circleId: string) => [
       {
         name: "동아리원 관리",
         link: `/setting/management/circle/${circleId}/member`,
@@ -89,9 +87,14 @@ const SettingsPage = () => {
       },
     ],
 
-    게시판관리: [
+    boardManagement: [
       { name: "게시판 생성 신청 관리", link: "/setting/management/board" },
     ],
+
+    occasionManagement: [
+      { name: "경조사 관리", link: "/setting/occasion"}
+    ]
+
   };
 
   const MenuItem: React.FC<{
@@ -119,8 +122,8 @@ const SettingsPage = () => {
     return (
       <>
         {/* 기본 유저들에게 나타나는 UI */}
-        <MenuItem title="계정" items={menuItems.계정} />
-        <MenuItem title="기록" items={menuItems.기록} />
+        <MenuItem title="계정" items={menuItems.account} />
+        <MenuItem title="기록" items={menuItems.records} />
 
         {/* 권한을 갖는 유저들에게 나타나는 UI */}
 
@@ -128,7 +131,7 @@ const SettingsPage = () => {
         {(isCouncil() && !isCircleLeader()) ||
           (isStudentLeader() && !isCircleLeader && (
             <>
-              <MenuItem title="권한 위임" items={menuItems.권한위임} />
+              <MenuItem title="권한 위임" items={menuItems.delegation} />
             </>
           ))}
 
@@ -151,8 +154,8 @@ const SettingsPage = () => {
         {/* 동문회장 */}
         {isAlumniLeader() && (
           <>
-            <MenuItem title="관리" items={menuItems.관리_동문회장} />
-            <MenuItem title="권한 위임" items={menuItems.권한위임} />
+            <MenuItem title="관리" items={menuItems.managementAlumniPresident} />
+            <MenuItem title="권한 위임" items={menuItems.delegation} />
           </>
         )}
 
@@ -161,11 +164,12 @@ const SettingsPage = () => {
           <>
             <MenuItem
               title="관리"
-              items={menuItems.관리_관리자_학생회장_부학생회장}
+              items={menuItems.managementAdmin}
             />
-            <MenuItem title="권한 위임" items={menuItems.권한위임} />
-            <MenuItem title="홈 화면 관리" items={menuItems.홈화면관리} />
-            <MenuItem title="게시판 관리" items={menuItems.게시판관리} />
+            <MenuItem title="권한 위임" items={menuItems.delegation} />
+            <MenuItem title="홈 화면 관리" items={menuItems.homeManagement} />
+            <MenuItem title="게시판 관리" items={menuItems.boardManagement} />
+            <MenuItem title="경조사 관리" items={menuItems.occasionManagement} />
           </>
         )}
       </>

--- a/src/widget/SideBar.tsx
+++ b/src/widget/SideBar.tsx
@@ -2,13 +2,41 @@
 
 import { useEffect } from "react";
 
-import { ProfileImage, Header, SubHeader } from "@/entities";
+import { ProfileImage, SubHeader } from "@/entities";
 import {
   UserService,
   useUserStore,
   AuthRscService,
   useLayoutStore,
 } from "@/shared";
+import Link from "next/link";
+
+interface NotificationItemProps {
+  title: string;
+  timeInfo: string;
+}
+
+const NotificationItem: React.FC<NotificationItemProps> = ({ title, timeInfo }) => {
+  return (
+    <div className="flex items-center p-3 border border-gray-300 rounded-lg shadow bg-gray-50">
+      <div className="text-yellow-400 text-xl mr-3">📝</div>
+      <div>
+        <p className="text-sm font-medium">{title}</p>
+        <p className="text-xs text-gray-500">{timeInfo}</p>
+      </div>
+    </div>
+  );
+};
+
+const notifications = [
+  { title: "홍길동(17) - 결혼", timeInfo: "2025.03.01" },
+  { title: "홍길동(17) - 결혼", timeInfo: "2025.03.01" },
+  { title: "홍길동(17) - 결혼", timeInfo: "2025.03.01" },
+  { title: "홍길동(17) - 결혼", timeInfo: "2025.03.01" },
+  
+]; // 나중에 api 호출 받아오는 걸로 변경
+
+
 
 export const SideBar = () => {
   const { getMe } = UserService();
@@ -52,6 +80,34 @@ export const SideBar = () => {
           <SubHeader big>{name}</SubHeader>
           <SubHeader gray>{email}</SubHeader>
         </div>
+    
+    <div className="max-xl:hidden">
+      <div className="w-72 mx-auto p-2 border-2 border-yellow-400 rounded-lg bg-white relative">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold flex items-center">
+            <span className="mr-2">📌</span> 최근 경조사 알림
+          </h2>
+
+        <Link href="/occasion/apply" className="px-4 py-1 bg-yellow-400 text-white text-sm font-medium rounded-full shadow">
+        신청
+      </Link>
+        </div>
+        <div className="space-y-3">
+          {notifications.map((notification, index) => (
+            <div className="space-y-3">
+            <Link href='/occasion' className="">
+            <NotificationItem
+              key={index}
+              title={notification.title}
+              timeInfo={notification.timeInfo}
+            />
+            </Link>
+            </div>
+          ))}
+        </div>
+      </div>  
+    </div>
+
         <div className="xl:hidden">
           <ProfileImage src={profileImage} />
         </div>

--- a/src/widget/SideBar.tsx
+++ b/src/widget/SideBar.tsx
@@ -68,9 +68,16 @@ export const SideBar = () => {
               handleNoRefresh();
             }}
           ></span>
-          <span className="text-xs text-black underline xl:text-sm">
+          <span className="text-xs text-black underline xl:text-sm hidden xl:block">
             로그아웃
           </span>
+
+          
+        </div>
+        <div className="absolute left-12 top-0 flex flex-col items-center text-black xl:hidden">
+          <Link href="/occasion">
+            <span className="icon-[codicon--bell] text-2xl text-black-400"></span>
+          </Link>
         </div>
 
         <div className="max-xl:hidden">


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호

📋 PR Checklist
-모바일 뷰 좌측 상단 알림 탭 추가
![모바일뷰 알림 추가, 글씨 제거](https://github.com/user-attachments/assets/d890c13c-3078-4859-a0fb-0c2edc6eee0e)

-관리자 설정 페이지 경조사 알림 메뉴 추가
![관리자 환경설정 탭에 경조사관리 탭 추가](https://github.com/user-attachments/assets/047b88eb-a5a3-4e9d-abe7-795aed6ec270)

-PC 뷰 우측 하단 경조사 알림 탭 추가
![사이드바에 경조사 알림 추가](https://github.com/user-attachments/assets/0766cdf1-03f1-4e0b-854b-ff49aa6c8b5d)

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
