### PR TITLE
[#132] 아이디, 비밀번호 찾기 시 API request body와 폼 전화번호 형식이 다른 문제 해결

### DIFF
--- a/src/app/auth/findemail/error.tsx
+++ b/src/app/auth/findemail/error.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Image from "next/image";
+
+export const Error = () => {
+  return (
+    <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-col items-center justify-center text-xl font-bold">
+      <Image
+        src="/images/puang-proud.png"
+        alt="404"
+        width={200}
+        height={250}
+      ></Image>
+      <span className="text-center">아이디 찾기 도중 에러가 발생했습니다.</span>
+    </div>
+  );
+};
+export default Error;

--- a/src/app/auth/findemail/layout.tsx
+++ b/src/app/auth/findemail/layout.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ToastWithMax } from "@/shared";
+
+const queryClient = new QueryClient();
+
+const QueryClientLayout = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) => (
+  <QueryClientProvider client={queryClient}>
+    <>
+      <ToastWithMax />
+      {children}
+    </>
+  </QueryClientProvider>
+);
+
+export default QueryClientLayout;

--- a/src/app/auth/findemail/page.tsx
+++ b/src/app/auth/findemail/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import React, { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { FormInput, FormSubmitButton, FormErrorMessage } from '@/entities';
-import axios from 'axios';
-import { BASEURL } from '@/shared';
+import { AuthService, useFindAccountStore } from "@/shared";
+import { FormErrorMessage, FormInput, FormSubmitButton } from "@/entities";
+import React, { useCallback } from "react";
+
+import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { useShallow } from "zustand/react/shallow";
 
 interface FormData {
   studentId: string;
@@ -12,94 +14,138 @@ interface FormData {
   phoneNumber: string;
 }
 
-const FindEmailPage: React.FC = () => {
-  const { register, handleSubmit, formState: { errors }, setError } = useForm<FormData>();
-  const [email, setEmail] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+const FindEmailPage = () => {
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>();
 
+  const {
+    email,
+    setName,
+    setStudentId,
+    setPhoneNumber,
+    resetFindAccountStore,
+  } = useFindAccountStore(
+    useShallow((state) => ({
+      email: state.email,
+      setName: state.setName,
+      setStudentId: state.setStudentId,
+      setPhoneNumber: state.setPhoneNumber,
+      resetFindAccountStore: state.resetFindAccountStore,
+    })),
+  );
+
+  const { useFindId } = AuthService();
+  const { mutate: findId } = useFindId();
   const onSubmit = async (data: FormData) => {
-    // 전화번호의 '-'를 제거
-    const cleanedPhoneNumber = data.phoneNumber.replace(/-/g, '');
-    // 추가적인 유효성 검사를 통해 데이터가 올바른지 확인
-    if (cleanedPhoneNumber.length < 10 || cleanedPhoneNumber.length > 11) {
-      setError('phoneNumber', {
-        type: 'manual',
-        message: '연락처는 10자리 또는 11자리여야 합니다.',
-      });
-      return;
-    }
+    setStudentId(data.studentId);
+    setName(data.name);
+    setPhoneNumber(data.phoneNumber);
 
-    try {
-      const response = await axios.post(`${BASEURL}/api/v1/users/user-id/find`, {
-        studentId: data.studentId,
-        name: data.name,
-        phoneNumber: cleanedPhoneNumber // phoneNumber에서 "-" 제거된 값을 사용
-      });
+    findId({
+      studentId: data.studentId,
+      name: data.name,
+      phoneNumber: data.phoneNumber,
+    });
+  };
 
-      if (response.status === 200) {
-        console.log("API Response Data: ", response.data);
-        setEmail(response.data.email); // 이메일 업데이트
-        setErrorMessage(null);
-      } else {
-        console.log("API Error: ", response.data);
-        setErrorMessage(response.data.message || '사용자를 찾을 수 없습니다.');
-        setEmail(null);
-      }
-    } catch (error: any) {
-      // 서버에서 발생한 오류 메시지를 반영하여 출력
-      const errorMsg = error.response?.data?.message || '서버와 통신하는 도중 오류가 발생했습니다.';
-      console.error("Fetch Error: ", error);
-      setErrorMessage(errorMsg);
-      setEmail(null);
-    }
+  const handleRouteLogin = () => {
+    router.push("/auth/signin");
+  };
+
+  const handleRouteFindPassword = () => {
+    router.push("/auth/findpassword");
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-white px-4 sm:px-0">
-      {email ? (
-        <div className="w-full max-w-md bg-white p-8 rounded-lg shadow-md text-center">
-          <h2 className="text-xl font-semibold mb-4">당신의 아이디(이메일)은</h2>
-          <p className="text-red-500 text-lg">{email}</p>
+    <div
+      className="flex min-h-screen flex-col items-center justify-center bg-white px-4 sm:px-0"
+      ref={useCallback(() => {
+        resetFindAccountStore();
+      }, [])}
+    >
+      {email !== "" ? (
+        <div className="w-full max-w-md rounded-lg bg-white p-8 text-center shadow-md">
+          <h2 className="mb-4 text-xl font-semibold">
+            당신의 아이디(이메일)은
+          </h2>
+          <p className="text-lg">
+            <span className="text-red-500">{email}</span> 입니다.
+          </p>
+          <div className="mt-4 flex w-full justify-between px-4">
+            <button
+              className="mt-5 h-10 w-32 rounded-xl bg-blue-500 text-white"
+              onClick={handleRouteLogin}
+            >
+              로그인하기
+            </button>
+            <button
+              className="mt-5 h-10 w-32 rounded-xl bg-blue-500 text-white"
+              onClick={handleRouteFindPassword}
+            >
+              비밀번호 찾기
+            </button>
+          </div>
         </div>
       ) : (
-        <form onSubmit={handleSubmit(onSubmit)} className="w-full max-w-md bg-white p-8 rounded-lg shadow-md">
-          <h2 className="text-xl font-semibold mb-4">아이디(이메일)를 찾고 싶으신가요?</h2>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="w-full max-w-md rounded-lg bg-white p-8 shadow-md"
+        >
+          <h2 className="mb-4 text-base font-semibold md:text-xl">
+            아이디(이메일)를 찾고 싶으신가요?
+          </h2>
 
-          <h2 className="text-xl font-semibold mt-4 mb-4">학번을 입력해주세요.</h2>
+          <h2 className="mb-4 mt-4 text-xl font-semibold">
+            학번을 입력해주세요.
+          </h2>
           <FormInput
             name="studentId"
             type="text"
             placeholder="현재 학번을 입력해주세요(숫자)"
             register={register}
-            rules={{ required: '학번을 입력해주세요.', pattern: { value: /^\d{8}$/, message: '학번은 8자리 숫자여야 합니다.' } }}
+            rules={{
+              required: "학번을 입력해주세요.",
+              pattern: {
+                value: /^\d{8}$/,
+                message: "학번은 8자리 숫자여야 합니다.",
+              },
+            }}
           />
           <FormErrorMessage message={errors.studentId?.message} />
 
-          <h2 className="text-xl font-semibold mt-4 mb-4">이름을 입력해주세요.</h2>
+          <h2 className="mb-4 mt-4 text-xl font-semibold">
+            이름을 입력해주세요.
+          </h2>
           <FormInput
             name="name"
             type="text"
             placeholder="한글, 영문 대/소문자를 사용해 주세요. (특수기호, 공백 사용 불가)"
             register={register}
-            rules={{ required: '이름을 입력해주세요.' }}
+            rules={{ required: "이름을 입력해주세요." }}
           />
           <FormErrorMessage message={errors.name?.message} />
 
-          <h2 className="text-xl font-semibold mt-4 mb-4">연락처를 입력해주세요.</h2>
+          <h2 className="mb-4 mt-4 text-xl font-semibold">
+            전화번호를 입력해주세요.
+          </h2>
           <FormInput
             name="phoneNumber"
             type="text"
-            placeholder="- 를 빼서 작성해주세요. 예) 01012345678"
+            placeholder="'-'을 포함해서 입력해주세요 ex) 010-1234-5678"
             register={register}
             rules={{
-              required: '연락처를 입력해주세요.',
-              pattern: { value: /^01[016789][0-9]{7,8}$/, message: '올바른 연락처를 입력해주세요.' },
+              required: "연락처를 입력해주세요.",
+              pattern: {
+                value: /^010-[0-9]{4}-[0-9]{4}$/,
+                message: "010-0000-0000 형식으로 입력해주세요.",
+              },
             }}
           />
           <FormErrorMessage message={errors.phoneNumber?.message} />
-
-          {errorMessage && <FormErrorMessage message={errorMessage} />}
-
           <FormSubmitButton />
         </form>
       )}

--- a/src/app/auth/findpassword/error.tsx
+++ b/src/app/auth/findpassword/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Image from "next/image";
+
+export const Error = () => {
+  return (
+    <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 transform flex-col items-center justify-center text-xl font-bold">
+      <Image
+        src="/images/puang-proud.png"
+        alt="404"
+        width={200}
+        height={250}
+      ></Image>
+      <span className="text-center">
+        비밀번호 찾기 도중 에러가 발생했습니다.
+      </span>
+    </div>
+  );
+};
+export default Error;

--- a/src/app/auth/findpassword/layout.tsx
+++ b/src/app/auth/findpassword/layout.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ToastWithMax } from "@/shared";
+
+const queryClient = new QueryClient();
+
+const QueryClientLayout = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) => (
+  <QueryClientProvider client={queryClient}>
+    <>
+      <ToastWithMax />
+      {children}
+    </>
+  </QueryClientProvider>
+);
+
+export default QueryClientLayout;

--- a/src/shared/hooks/services/AuthService.tsx
+++ b/src/shared/hooks/services/AuthService.tsx
@@ -1,17 +1,21 @@
 "use client";
 
-import axios, { AxiosResponse } from "axios";
-import { useRouter } from "next/navigation";
-
 import {
   API,
   BASEURL,
+  UserService,
   setRccToken,
   setRscToken,
+  useFindAccountStore,
   useLayoutStore,
-  UserService,
   useUserStore,
 } from "@/shared";
+import axios, { AxiosResponse } from "axios";
+
+import toast from "react-hot-toast";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useShallow } from "zustand/react/shallow";
 
 export const AuthService = () => {
   const URI = "/api/v1/users";
@@ -53,8 +57,8 @@ export const AuthService = () => {
   const signup = async (selectedData: User.SignUpFormPost) => {
     try {
       // axios POST 요청
-      console.log(`${BASEURL}${URI}/sign-up`)
-      console.log(selectedData)
+      console.log(`${BASEURL}${URI}/sign-up`);
+      console.log(selectedData);
       const response = await axios.post(
         `${BASEURL}${URI}/sign-up`,
         selectedData,
@@ -70,7 +74,7 @@ export const AuthService = () => {
       if (axios.isAxiosError(error)) {
         // Axios 에러 처리
         const errorMessage = error.response?.data?.message;
-        console.log(error)
+        console.log(error);
         throw new Error(errorMessage); // 에러 메시지를 던져서 onSubmit에서 처리할 수 있게 함
       } else {
         console.error("General error:", error);
@@ -139,11 +143,81 @@ export const AuthService = () => {
     }
   };
 
+  const useFindId = () => {
+    const { setEmail, resetFindAccountStore } = useFindAccountStore(
+      useShallow((state) => ({
+        setEmail: state.setEmail,
+        resetFindAccountStore: state.resetFindAccountStore,
+      })),
+    );
+    return useMutation({
+      mutationFn: async ({
+        studentId,
+        name,
+        phoneNumber,
+      }: {
+        studentId: string;
+        name: string;
+        phoneNumber: string;
+      }) => {
+        const { data }: { data: { email: string } } = await API.post(
+          `/api/v1/users/user-id/find`,
+          {
+            studentId,
+            name,
+            phoneNumber,
+          },
+        );
+        return data.email;
+      },
+      onSuccess: (data) => {
+        setEmail(data);
+      },
+      onError: () => {
+        toast.error("사용자를 찾을 수 없습니다.");
+        resetFindAccountStore();
+      },
+    });
+  };
+
+  const useFindPassword = () => {
+    return useMutation({
+      mutationFn: async ({
+        name,
+        studentId,
+        phoneNumber,
+        email,
+      }: {
+        name: string;
+        studentId: string;
+        phoneNumber: string;
+        email: string;
+      }) => {
+        await API.put("/api/v1/users/password/find", {
+          name,
+          studentId,
+          phoneNumber,
+          email,
+        });
+      },
+      onMutate: () => {
+        toast.loading("비밀번호 찾는 중...");
+      },
+      onSuccess: () => {
+        toast.success("비밀번호 재설정 이메일이 전송되었습니다.");
+      },
+      onError: () => {
+        toast.error("사용자를 찾을 수 없습니다.");
+      },
+    });
+  };
   return {
     signin,
     signup,
     checkEmailDuplicate,
     checkNicknameDuplicate,
     checkStudentIdDuplicate,
+    useFindId,
+    useFindPassword,
   };
 };

--- a/src/shared/hooks/stores/useFindAccountStore.ts
+++ b/src/shared/hooks/stores/useFindAccountStore.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+interface FindAccountStore {
+  studentId: string;
+  name: string;
+  phoneNumber: string;
+  email: string;
+  setStudentId: (studentId: string) => void;
+  setName: (name1: string) => void;
+  setPhoneNumber: (phoneNumber: string) => void;
+  setEmail: (email: string) => void;
+  resetFindAccountStore: () => void;
+}
+
+export const useFindAccountStore = create<FindAccountStore>((set) => ({
+  studentId: "",
+  name: "",
+  phoneNumber: "",
+  email: "",
+  setStudentId: (studentId) => set({ studentId }),
+  setName: (name) => set({ name }),
+  setPhoneNumber: (phoneNumber) => set({ phoneNumber }),
+
+  setEmail: (email) => set({ email }),
+  resetFindAccountStore: () =>
+    set({
+      studentId: "",
+      name: "",
+      phoneNumber: "",
+      email: "",
+    }),
+}));

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -55,6 +55,7 @@ export { useFileUploadStore } from "./hooks/stores/post/create/useFileUploadStor
 export { useResponseFormStore } from "./hooks/stores/post/form/useResponseFormStore";
 export { useFormResultStore } from "./hooks/stores/post/form/useFormResultStore";
 export { useLockerSelectionStore } from "./hooks/stores/locker/useLockerSelectionStore";
+export { useFindAccountStore } from "./hooks/stores/useFindAccountStore";
 
 //Listener
 export { WindowSizeListener } from "./listener/WindowSizeListener";


### PR DESCRIPTION
🚩 관련 이슈
ex) #132 

📋 PR Checklist

- [x] 아이디, 비밀번호 찾기 시 전화번호 유효성 검사 000-0000-0000으로 진행하도록 변경
- [x] 아이디 찾기 성공 시 로그인 창 혹은 비밀번호 찾기 창으로 이동하는 버튼이 나오도록 변경
- [x] 아이디 찾기 성공 후 비밀번호 찾기 페이지로 이동 시 자동으로 사용자의 정보가 입력되도록 변경 

📌 유의사항
✅ 테스트 결과
![CAUSWV2-Chrome2025-03-0500-28-56-ezgif com-video-to-gif-converter (1)](https://github.com/user-attachments/assets/b88e5875-54d8-44ac-af58-7f12560606c4)


