### PR TITLE
[FIX] 유저 정보 상세보기 페이지에서 재학증빙 서류 이미지 에러 해결

### DIFF
--- a/src/entities/home/setting/management/AdmissionManagementDetailEntities.ts
+++ b/src/entities/home/setting/management/AdmissionManagementDetailEntities.ts
@@ -264,5 +264,11 @@ export const titleMappingForCircle = Object.keys(titleMapping)
 
 export const titleMappingForRejected: Record<keyof any, string> = {
   ...titleMapping, // 기존 타이틀 매핑을 그대로 가져옴
+  evidentImg: "학부 재적/졸업 증빙 자료",
   rejectionOrDropReason: "거부/ 추방 사유", // 추가된 항목
+};
+
+export const titleMappingForUser: Record<keyof any, string> = {
+  ...titleMapping, // 기존 타이틀 매핑을 그대로 가져옴
+  evidentImg: "학부 재적/졸업 증빙 자료",
 };

--- a/src/shared/hooks/services/UserRscService.tsx
+++ b/src/shared/hooks/services/UserRscService.tsx
@@ -35,6 +35,22 @@ export const UserRscService = () => {
     }
   };
 
+  const getUserAcademicRecord = async (id: string) => {
+    try {
+      const headers = await setRscHeader();
+      const response = (await fetch(`${URI}/academic-record/record/${id}`, { headers: headers }).then(
+        (res) => res.json(),
+      )) as any;
+
+      if (response.errorCode) throw new Error(response.errorCode);
+
+      return response;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  };
+
   const getMyCircles = async () => {
     try {
       const headers = await setRscHeader();
@@ -193,5 +209,6 @@ export const UserRscService = () => {
     updateInfo,
     submitAdmissionsApplication,
     modifyAdmissionApplication,
+    getUserAcademicRecord
   };
 };

--- a/src/widget/AdmissionManagementDetail.tsx
+++ b/src/widget/AdmissionManagementDetail.tsx
@@ -8,6 +8,7 @@ import {
   convertUserDataToTableEntity,
   titleMapping,
   titleMappingForRejected,
+  titleMappingForUser,
 } from "@/entities/home/setting/management/AdmissionManagementDetailEntities";
 import { SettingRscService } from "@/shared";
 import { ManagementState } from "./Management";
@@ -25,7 +26,7 @@ export async function ManagementDetail({
   const entities = managementDetailEntities[state];
   const { titleSuffix } = entities;
   const { getAdmission } = SettingRscService();
-  const { getUser } = UserRscService();
+  const { getUser, getUserAcademicRecord } = UserRscService();
   let admission;
 
   if (state === "admission" || state === "reject") {
@@ -41,6 +42,12 @@ export async function ManagementDetail({
     userInfo = await getUser(admissionId);
   } catch (error) {
     console.log("유저 정보 조회 실패", error);
+  }
+  try {
+  const response = await getUserAcademicRecord(admissionId);
+  userInfo.profileImageUrl = response.userAcademicRecordApplicationResponseDtoList[0].attachedImageUrlList[0]; }
+  catch {
+    console.log("정보 조회 실패")
   }
 
   let name;
@@ -80,7 +87,7 @@ export async function ManagementDetail({
         <div>
           <ManagementDetailInfoTable
             data={convertUserDataToTableEntity(userInfo)}
-            titleMapping={titleMapping}
+            titleMapping={titleMappingForUser}
           />
           <ManagementDetailButtons state={state} admission={userInfo} />
         </div>

--- a/src/widget/Management.tsx
+++ b/src/widget/Management.tsx
@@ -2,9 +2,7 @@
 
 import { ExcelExport, Header, Line } from "@/entities";
 import { PaginationButtons } from "@/shared";
-
 import Link from "next/link";
-import { Pagination } from "swiper/modules";
 
 export type ManagementState =
   | "admission"

--- a/src/widget/ManagementDetailInfoTable.tsx
+++ b/src/widget/ManagementDetailInfoTable.tsx
@@ -4,8 +4,6 @@ import Image from "next/image";
 import { Dispatch, ReactNode, SetStateAction, useState } from "react";
 import { ImageModal, PreviousButton } from "@/shared";
 
-import { Modal } from "@/entities";
-
 const TableUnit = ({
   title,
   data,
@@ -22,7 +20,7 @@ const TableUnit = ({
       title === "가입 신청서 첨부 이미지" ? (
         data ? (
           <Image
-            className={data === "" ? "invisible rounded-md" : "rounded-md"}
+            className={data === "" ? "invisible rounded-md" : "rounded-md mt-8 mb-8"}
             src={data}
             alt={title}
             width={200}
@@ -59,7 +57,7 @@ export function ManagementDetailInfoTable({
         {selectedImage && <ImageModal imageUrl={selectedImage} onClose={() => setSelectedImage(null)} />}
       <div className="grid h-full grid-cols-2 justify-around gap-y-[27px] pt-4 font-semibold lg:w-[700px] lg:pt-8">
         <PreviousButton></PreviousButton>
-        {Object.keys(data).map((k) => {
+        {Object.keys(data).filter((key) => key in titleMapping).map((k) => {
           const key = k as keyof typeof data;
           return (
             <TableUnit


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호

📋 PR Checklist
- 관리자 유저 관리 -> 유저 정보 상세 보기에서 재학 증빙 서류 이미지 에러 해결

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
