### PR TITLE
[FEAT/#203] 게시글 컨텐츠 HTML 렌더링 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "axios": "^1.6.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dompurify": "^3.2.6",
         "firebase": "^11.3.0",
         "js-cookie": "^3.0.5",
         "lucide-react": "^0.510.0",
@@ -4621,6 +4622,12 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
@@ -5870,6 +5877,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -8086,13 +8101,10 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/lucide-react": {
       "version": "0.510.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dompurify": "^3.2.6",
     "firebase": "^11.3.0",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.510.0",

--- a/src/fsd_entities/post/ui/PostCard/PostCard.tsx
+++ b/src/fsd_entities/post/ui/PostCard/PostCard.tsx
@@ -17,13 +17,13 @@ export const PostCard = ({ post, targetUrl }: PostCardProps) => {
 
   return (
     <div
-      className="flex max-h-44 w-full items-center rounded-xl bg-white p-4 shadow-lg lg:p-6"
+      className="flex h-44 w-full items-center rounded-xl bg-white p-4 shadow-lg lg:p-6"
       onClick={() => {
         targetUrl ? router.push(targetUrl) : router.push(`${pathname}/${post.id}`);
       }}
     >
-      <div className="flex w-full flex-col">
-        <div className="flex w-full items-center justify-between">
+      <div className="grid h-full w-full grid-rows-[1fr_1.5rem]">
+        <div className="flex h-full w-full items-center justify-between">
           <PostCardContent post={post} />
           <div className="h-16 w-16 shrink-0 overflow-hidden sm:h-24 sm:w-24">
             {post.postAttachImage && (

--- a/src/fsd_entities/post/ui/PostCard/PostCardContent.tsx
+++ b/src/fsd_entities/post/ui/PostCard/PostCardContent.tsx
@@ -1,33 +1,48 @@
+'use client';
+
+import DOMPurify from 'dompurify';
+
 interface PostCardContentProps {
   post: Post.PostResponseDto;
 }
 
 export const PostCardContent = ({ post }: PostCardContentProps) => {
+  const sanitizedContent = DOMPurify.sanitize(post.content, {
+    // 기본적으로 허용된 태그에 목록, 링크, 코드 관련 태그 추가 h태그는 제목이라서 제외함
+    ALLOWED_TAGS: [
+      'p',
+      'span',
+      'b',
+      'i',
+      'u',
+      's',
+      'strong',
+      'em',
+      'ul',
+      'ol',
+      'li',
+      'a',
+      'br',
+      'blockquote',
+      'code',
+      'pre',
+      'hr',
+    ],
+    // a 태그에 허용할 속성 명시
+    ALLOWED_ATTR: ['href', 'target', 'rel'],
+  });
+
   return (
-    <div className="flex w-2/3 flex-col">
-      <div className="flex-auto truncate">
-        <p className="overflow-hidden pb-2 text-sm font-bold text-ellipsis whitespace-nowrap md:text-2xl">
-          {post.title}
-        </p>
+    <div className="grid h-[96px] grow grid-rows-[2rem_1fr]">
+      <div className="w-full truncate">
+        <p className="overflow-hidden text-sm font-bold text-ellipsis whitespace-nowrap md:text-2xl">{post.title}</p>
       </div>
-      <div className="md:text-md pb-2 text-sm">
-        {post.content ? (
-          post.content
-            .split('\n')
-            .slice(0, 2)
-            .map((str, idx) => {
-              if (idx === 1 && post.content.split('\n').length > 2) {
-                return <p key={idx}>{str}...</p>;
-              }
-              return (
-                <p key={idx} className="truncate">
-                  {str}
-                </p>
-              );
-            })
-        ) : (
-          <p></p>
-        )}
+      <div className="relative min-h-0">
+        <div
+          className="md:text-md h-full overflow-y-hidden text-sm"
+          dangerouslySetInnerHTML={{ __html: sanitizedContent }}
+        />
+        <div className="pointer-events-none absolute bottom-0 left-0 h-10 w-full bg-linear-to-t from-white to-transparent" />
       </div>
     </div>
   );

--- a/src/fsd_entities/post/ui/PostDetailContent/PostDetailContent.tsx
+++ b/src/fsd_entities/post/ui/PostDetailContent/PostDetailContent.tsx
@@ -1,6 +1,12 @@
+'use client';
+
+import DOMPurify from 'dompurify';
+
 interface PostDetailContentProps {
   postContent: Post.PostDto['content'];
 }
 export const PostDetailContent = ({ postContent }: PostDetailContentProps) => {
-  return <p className="text-base break-words whitespace-pre-line select-text">{postContent}</p>;
+  const sanitizedContent = DOMPurify.sanitize(postContent);
+
+  return <div dangerouslySetInnerHTML={{ __html: sanitizedContent }} />;
 };


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호
#203 
📋 PR Checklist

- 크롤링되어 생성된 게시글을 innerHTML을 활용하여 렌더링하는 기능 추가
  - [x] 게시글 목록 페이지
  - [x] 게시글 상세 페이지

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브

https://github.com/user-attachments/assets/5d78a5f2-b03a-4e4a-bf0c-0445babaaebc

