### PR TITLE
[FEAT] 경조사에 알림 학번 추가 및 경조사 상세 토스트 에러 수정

### DIFF
--- a/src/app/(causw)/ceremony/[ceremonyId]/page.tsx
+++ b/src/app/(causw)/ceremony/[ceremonyId]/page.tsx
@@ -9,6 +9,7 @@ import { PreviousButton } from '@/fsd_shared';
 
 const OccasionNotificationDetailPage = () => {
   const { ceremonyId } = useParams<{ ceremonyId: string }>();
+
   return (
     <div className="w-full p-6">
       <PreviousButton />

--- a/src/app/(causw)/ceremony/setting/page.tsx
+++ b/src/app/(causw)/ceremony/setting/page.tsx
@@ -1,16 +1,15 @@
 'use client';
 
 import { NotificationSettingWidget } from '@/fsd_widgets/ceremony';
+
 import { PreviousButton } from '@/fsd_shared';
 
 export default function NotificationSettingPage() {
   return (
     <div className="relative top-3 left-4 w-[calc(100%-2rem)] pb-12 md:top-14 md:left-14 md:w-[calc(100%-7rem)]">
       <PreviousButton className="mb-8" />
-      <div className="mb-14 text-center text-2xl font-medium md:text-3xl">
-        경조사 알림 설정
-      </div>
-      <NotificationSettingWidget />
+      <div className="mb-14 text-center text-2xl font-medium md:text-3xl">경조사 알림 설정</div>
+      <NotificationSettingWidget isSettingPage={true} />
     </div>
   );
 }

--- a/src/app/(causw)/setting/notification/page.tsx
+++ b/src/app/(causw)/setting/notification/page.tsx
@@ -1,19 +1,14 @@
 'use client';
 
 import { NotificationActionButtons, NotificationTabs } from '@/fsd_widgets/notification';
+
 import {
   useCeremonyNotificationQuery,
   useNotificationQuery,
   useNotificationTabParam,
 } from '@/fsd_entities/notification';
 
-import {
-  ERROR_MESSAGES,
-  ListBox,
-  MESSAGES,
-  NOTIFICATION_TAB,
-  PreviousButton,
-} from '@/fsd_shared';
+import { ERROR_MESSAGES, ListBox, MESSAGES, NOTIFICATION_TAB, PreviousButton } from '@/fsd_shared';
 
 import BellIcon from '../../../../../public/icons/bell_icon.svg';
 
@@ -82,6 +77,7 @@ const Notification = () => {
             fetchNextCeremony();
           }
         }}
+        hideNotificationYearList={true}
       />
     ),
   };

--- a/src/fsd_entities/ceremony/model/index.ts
+++ b/src/fsd_entities/ceremony/model/index.ts
@@ -1,3 +1,4 @@
-export { useCeremonyData } from './useAdminCeremonyData';
+export { useAdminCeremonyData } from './useAdminCeremonyData';
 export { useCeremonyCreateForm } from './useCeremonyCreateForm';
 export { useCeremonySettingForm } from './useCeremonySettingForm';
+export { useCeremonyData } from './useCeremonyDetailData';

--- a/src/fsd_entities/ceremony/model/useAdminCeremonyData.ts
+++ b/src/fsd_entities/ceremony/model/useAdminCeremonyData.ts
@@ -8,19 +8,9 @@ import { ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 
 import { getAdminCeremonyAwaitList, getAdminCeremonyDetail } from '../api';
 
-export const useCeremonyData = (ceremonyId?: string) => {
+export const useAdminCeremonyData = () => {
   const [ceremonyList, setCeremonyList] = useState<Ceremony.CeremonyItem[]>([]);
-  const [ceremonyDetails, setCeremonyDetails] = useState({
-    title: '',
-    type: '',
-    register: '',
-    content: '',
-    startDate: '',
-    endDate: '',
-    imageList: [] as string[],
-    applicantName: '',
-    applicantStudentId: '',
-  });
+
   const fetchCeremonyList = async () => {
     try {
       const data = await getAdminCeremonyAwaitList(0, 10);
@@ -34,32 +24,5 @@ export const useCeremonyData = (ceremonyId?: string) => {
     fetchCeremonyList();
   }, []);
 
-  useEffect(() => {
-    if (ceremonyId) {
-      const fetchCeremonyDetail = async () => {
-        try {
-          const cermonyContent = await getAdminCeremonyDetail(ceremonyId);
-          const matchedCeremony = ceremonyList.find((item) => item.id === ceremonyId);
-
-          setCeremonyDetails({
-            title: matchedCeremony ? matchedCeremony.title : cermonyContent.description,
-            type: cermonyContent.category,
-            register: cermonyContent.ceremonyState,
-            content: cermonyContent.description,
-            startDate: cermonyContent.startDate,
-            endDate: cermonyContent.endDate,
-            imageList: cermonyContent.attachedImageUrlList,
-            applicantName: cermonyContent.applicantName,
-            applicantStudentId: cermonyContent.applicantStudentId,
-          });
-        } catch (error) {
-          toast.error(`${MESSAGES.CEREMONY.DETAIL_CONTENT_TITLE} - ${ERROR_MESSAGES.DETAIL_CONTENT_FETCH_FAIL}`);
-        }
-      };
-
-      fetchCeremonyDetail();
-    }
-  }, [ceremonyId, ceremonyList]);
-
-  return { ceremonyList, ceremonyDetails };
+  return ceremonyList;
 };

--- a/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
+++ b/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
@@ -26,10 +26,9 @@ export const useCeremonyData = (ceremonyId?: string) => {
       const fetchCeremonyDetail = async () => {
         try {
           const cermonyContent = await getAdminCeremonyDetail(ceremonyId);
-          // const matchedCeremony = ceremonyList.find((item) => item.id === ceremonyId);
 
           setCeremonyDetails({
-            title: '결혼',
+            title: cermonyContent.title,
             type: cermonyContent.category,
             register: cermonyContent.ceremonyState,
             content: cermonyContent.description,

--- a/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
+++ b/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import toast from 'react-hot-toast';
+
+import { ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
+
+import { getAdminCeremonyDetail } from '../api';
+
+export const useCeremonyData = (ceremonyId?: string) => {
+  const [ceremonyDetails, setCeremonyDetails] = useState({
+    title: '',
+    type: '',
+    register: '',
+    content: '',
+    startDate: '',
+    endDate: '',
+    imageList: [] as string[],
+    applicantName: '',
+    applicantStudentId: '',
+  });
+
+  useEffect(() => {
+    if (ceremonyId) {
+      const fetchCeremonyDetail = async () => {
+        try {
+          const cermonyContent = await getAdminCeremonyDetail(ceremonyId);
+          // const matchedCeremony = ceremonyList.find((item) => item.id === ceremonyId);
+
+          setCeremonyDetails({
+            title: '결혼',
+            type: cermonyContent.category,
+            register: cermonyContent.ceremonyState,
+            content: cermonyContent.description,
+            startDate: cermonyContent.startDate,
+            endDate: cermonyContent.endDate,
+            imageList: cermonyContent.attachedImageUrlList,
+            applicantName: cermonyContent.applicantName,
+            applicantStudentId: cermonyContent.applicantStudentId,
+          });
+        } catch (error) {
+          toast.error(`${MESSAGES.CEREMONY.DETAIL_CONTENT_TITLE} - ${ERROR_MESSAGES.DETAIL_CONTENT_FETCH_FAIL}`);
+        }
+      };
+
+      fetchCeremonyDetail();
+    }
+  }, [ceremonyId]);
+
+  return ceremonyDetails;
+};

--- a/src/fsd_entities/ceremony/ui/AdmissionYearInput.tsx
+++ b/src/fsd_entities/ceremony/ui/AdmissionYearInput.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from 'react';
 
+import clsx from 'clsx';
+
 import { Button } from '@/fsd_shared';
 
-export const AdmissionYearInput = ({ onAdd, disabled }: Ceremony.AdmissionYearInputProps) => {
+export const AdmissionYearInput = ({ onAdd, disabled, isSettingPage = false }: Ceremony.AdmissionYearInputProps) => {
   const [year, setYear] = useState('');
 
   const handleAdd = () => {
@@ -21,10 +23,13 @@ export const AdmissionYearInput = ({ onAdd, disabled }: Ceremony.AdmissionYearIn
         type="number"
         value={year}
         onChange={(e) => setYear(e.target.value)}
-        className="w-10 border-b border-b-black bg-transparent px-1"
+        className={clsx(
+          'border-b border-b-black bg-transparent px-1',
+          isSettingPage ? 'w-10 border-b border-b-black bg-transparent px-1' : 'w-13 text-2xl',
+        )}
         disabled={disabled}
       />
-      <span className="mr-14 text-2xl">학번</span>
+      <span className={clsx(isSettingPage ? 'mr-14 text-2xl' : 'mr-9 text-xl')}>학번</span>
       <Button
         variant="BLUE"
         action={handleAdd}

--- a/src/fsd_entities/ceremony/ui/AdmissionYearList.tsx
+++ b/src/fsd_entities/ceremony/ui/AdmissionYearList.tsx
@@ -1,18 +1,30 @@
 'use client';
 
-export const AdmissionYearList = ({ years, onRemove, isAllSelected }: Ceremony.AdmissionYearListProps) => {
+import clsx from 'clsx';
+
+export const AdmissionYearList = ({
+  years,
+  onRemove,
+  isAllSelected,
+  isSettingPage = false,
+}: Ceremony.AdmissionYearListProps) => {
   return (
     <div
-      className={`h-72 w-72 overflow-y-auto rounded-xl border border-black p-5 ${
-        isAllSelected ? 'bg-gray-200' : 'bg-white'
-      }`}
+      className={clsx(
+        'overflow-y-auto rounded-xl border border-black p-5',
+        isAllSelected ? 'bg-gray-200' : 'bg-white',
+        isSettingPage ? 'h-72 w-72' : 'h-40 w-full sm:max-w-85',
+      )}
     >
       {years.map((year) => (
         <button
           key={year}
           onClick={() => onRemove(year)}
           type="button"
-          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-left hover:bg-gray-100"
+          className={clsx(
+            'flex w-full cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-left hover:bg-gray-100',
+            isSettingPage ? '' : 'text-xl',
+          )}
         >
           <span>{year}학번</span>
           <div className="h-0.5 w-4 scale-150 transform rounded-2xl bg-black"></div>

--- a/src/fsd_entities/ceremony/ui/AllYearToggle.tsx
+++ b/src/fsd_entities/ceremony/ui/AllYearToggle.tsx
@@ -1,10 +1,19 @@
 'use client';
 
-export const AllYearToggle = ({ checked, onChange }: Ceremony.AllYearToggleProps) => {
+import clsx from 'clsx';
+
+export const AllYearToggle = ({ checked, onChange, isSettingPage }: Ceremony.AllYearToggleProps) => {
   return (
-    <label className="flex items-center gap-2">
-      <span className="text-lg">모든 학번의 경조사 알림 받기</span>
-      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} className="h-5 w-5" />
+    <label className={clsx('flex items-center', isSettingPage ? 'gap-2' : 'gap-1')}>
+      <span className={clsx(isSettingPage ? 'text-lg' : 'ml-auto text-[15px]')}>
+        {isSettingPage ? '모든 학번의 경조사 알림 받기' : '모든 학번에게 알림 전송'}
+      </span>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className={clsx(isSettingPage ? 'h-5 w-5' : 'h-4 w-4')}
+      />
     </label>
   );
 };

--- a/src/fsd_shared/@types/ceremony.ts
+++ b/src/fsd_shared/@types/ceremony.ts
@@ -109,6 +109,7 @@ declare namespace Ceremony {
     alarm?: string; //general | ceremony
     loadMore?: () => void;
     emptyMessage?: string;
+    hideNotificationYearList?: boolean;
   }
   interface CreateCeremonyPayload {
     description: string;

--- a/src/fsd_shared/@types/ceremony.ts
+++ b/src/fsd_shared/@types/ceremony.ts
@@ -149,15 +149,18 @@ declare namespace Ceremony {
   interface AdmissionYearInputProps {
     onAdd: (year: number) => void;
     disabled: boolean;
+    isSettingPage?: boolean;
   }
   interface AdmissionYearListProps {
     years: number[];
     onRemove: (year: number) => void;
     isAllSelected?: boolean;
+    isSettingPage?: boolean;
   }
   interface AllYearToggleProps {
     checked: boolean;
     onChange: (val: boolean) => void;
+    isSettingPage?: boolean;
   }
   interface CeremonyNotificationSettingDto {
     subscribedAdmissionYears: number[] | null;

--- a/src/fsd_shared/configs/constants/messages.ts
+++ b/src/fsd_shared/configs/constants/messages.ts
@@ -20,5 +20,6 @@ export const MESSAGES = Object.freeze({
     ALL: '전체 알림',
     GENERAL: '알림',
     CEREMONY: '경조사',
+    YEAR_LIST: '경조사 알림 대상 학번',
   },
 });

--- a/src/fsd_shared/ui/CommonImageList.tsx
+++ b/src/fsd_shared/ui/CommonImageList.tsx
@@ -23,7 +23,7 @@ export const CommonImageList = ({ images }: CommonImageListProps) => {
     setIsViewerOpen(false);
     setSelectedIndex(null);
   };
-
+  if (images.length === 0) return;
   return (
     <div className="flex flex-col gap-2">
       <h1 className="text-lg font-bold md:text-2xl">사진</h1>

--- a/src/fsd_shared/ui/ListBox.tsx
+++ b/src/fsd_shared/ui/ListBox.tsx
@@ -9,10 +9,9 @@ import { useInfiniteScroll } from '@/fsd_shared/hooks/useInfiniteScroll';
 import MailIcon from '../../../public/icons/envelope_icon.svg';
 import MailOpendIcon from '../../../public/icons/envelope_open_icon.svg';
 
-export const ListBox = ({ data, alarm, loadMore, emptyMessage }: Ceremony.ListBoxProps) => {
+export const ListBox = ({ data, alarm, loadMore, emptyMessage, hideNotificationYearList }: Ceremony.ListBoxProps) => {
   const router = useRouter();
   const markAsRead = useNotificationStore((state) => state.markAsRead);
-
   const { targetRef } = useInfiniteScroll({
     intersectionCallback: ([entry]) => {
       if (entry.isIntersecting && loadMore) {
@@ -25,7 +24,7 @@ export const ListBox = ({ data, alarm, loadMore, emptyMessage }: Ceremony.ListBo
     <div className="max-h-[calc(100vh-22rem)] max-w-[560px] overflow-y-auto rounded-lg bg-[#D9D9D9] p-4 md:max-h-[calc(100vh-25rem)] xl:max-h-[calc(100vh-17rem)]">
       <div className="flex max-h-full flex-col space-y-4">
         {data.length === 0 ? (
-          <div className="flex h-20 items-center justify-center">{emptyMessage || "목록이 없습니다."}</div>
+          <div className="flex h-20 items-center justify-center">{emptyMessage || '목록이 없습니다.'}</div>
         ) : (
           data.map((item, index) => {
             const isItemRead = item.isRead ?? true;
@@ -34,8 +33,8 @@ export const ListBox = ({ data, alarm, loadMore, emptyMessage }: Ceremony.ListBo
               alarm === 'general'
                 ? `/board/${item.targetParentId}/${item.targetId}`
                 : item.targetId
-                  ? `/ceremony/${item.targetId}`
-                  : `/ceremony/${item.id}`;
+                  ? `/ceremony/${item.targetId}${hideNotificationYearList ? '?hideList=true' : ''}`
+                  : `/ceremony/${item.id}${hideNotificationYearList ? '?hideList=true' : ''}`;
             return (
               <div
                 onClick={() => {
@@ -61,9 +60,7 @@ export const ListBox = ({ data, alarm, loadMore, emptyMessage }: Ceremony.ListBo
                   />
                 )}
 
-                <div className="text-gray-600">
-                  {isItemRead ? <MailOpendIcon size={32} /> : <MailIcon size={32} />}
-                </div>
+                <div className="text-gray-600">{isItemRead ? <MailOpendIcon size={32} /> : <MailIcon size={32} />}</div>
                 <div className="text-left">
                   <div className="font-medium text-[#212323]">{item.title}</div>
                   <div className="text-sm text-[#212323]">{item.body}</div>

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -21,8 +21,9 @@ import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 import { ceremonyTypeMap } from '../config';
 
 export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
-  const { ceremonyDetails } = useCeremonyData(ceremonyId);
+  const ceremonyDetails = useCeremonyData(ceremonyId);
   const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];
+
   const router = useRouter();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const closeModal = () => {

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -19,6 +19,7 @@ import {
 import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 
 import { ceremonyTypeMap } from '../config';
+import { NotificationYearListBox } from './NotificationYearListBox';
 
 export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
   const ceremonyDetails = useCeremonyData(ceremonyId);
@@ -70,6 +71,9 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
           <CeremonyDateTile title={MESSAGES.CEREMONY.START_DATE} date={ceremonyDetails.startDate} />
           <CeremonyDateTile title={MESSAGES.CEREMONY.END_DATE} date={ceremonyDetails.endDate} />
         </div>
+
+        <h1 className="text-lg font-medium md:text-2xl">{MESSAGES.NOTIFICATION.YEAR_LIST}</h1>
+        <NotificationYearListBox />
 
         <CommonImageList images={ceremonyDetails.imageList} />
 

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -16,11 +16,13 @@ import {
   CeremonySectionTitle,
 } from '@/fsd_entities/ceremony';
 
-import { ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
+import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
+
+import { ceremonyTypeMap } from '../config';
 
 export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
   const { ceremonyDetails } = useCeremonyData(ceremonyId);
-
+  const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];
   const router = useRouter();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const closeModal = () => {
@@ -54,7 +56,7 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
     <>
       <div className="flex flex-col gap-3 pt-8 pb-10 md:gap-6">
         <div className="grid grid-cols-1 gap-3 md:gap-8 lg:grid-cols-2 lg:gap-32">
-          <CeremonySectionTitle title={MESSAGES.CEREMONY.CATEGORY} ceremonyContent={ceremonyDetails.type} />
+          <CeremonySectionTitle title={MESSAGES.CEREMONY.CATEGORY} ceremonyContent={ceremonyType} />
           <CeremonySectionTitle
             title={MESSAGES.CEREMONY.REGISTRANT}
             ceremonyContent={`${ceremonyDetails.applicantName}/${ceremonyDetails.applicantStudentId}`}
@@ -65,7 +67,7 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
           <CeremonyDateTile title={MESSAGES.CEREMONY.START_DATE} date={ceremonyDetails.startDate} />
           <CeremonyDateTile title={MESSAGES.CEREMONY.END_DATE} date={ceremonyDetails.endDate} />
         </div>
-        <CeremonyImageTile imageList={ceremonyDetails.imageList} />
+        <CommonImageList images={ceremonyDetails.imageList} />
         <div className="fixed bottom-20 left-0 z-10 flex w-full justify-center gap-5 md:pt-0 lg:gap-11 xl:left-auto xl:w-[calc(100%-29rem)]">
           <CeremonyApprovalButton color="BLUE" onClick={handleClickApprove} text={MESSAGES.CEREMONY.APPROVAL} />
           <CeremonyApprovalButton color="GRAY" onClick={handleClickReject} text={MESSAGES.CEREMONY.REJECTION} />

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -55,6 +55,8 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
 
   return (
     <>
+      {isModalOpen && <CeremonyApprovalModal closeModal={closeModal} ceremonyTitle={ceremonyDetails.title} />}
+
       <div className="flex flex-col gap-3 pt-8 pb-10 md:gap-6">
         <div className="grid grid-cols-1 gap-3 md:gap-8 lg:grid-cols-2 lg:gap-32">
           <CeremonySectionTitle title={MESSAGES.CEREMONY.CATEGORY} ceremonyContent={ceremonyType} />
@@ -68,13 +70,14 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
           <CeremonyDateTile title={MESSAGES.CEREMONY.START_DATE} date={ceremonyDetails.startDate} />
           <CeremonyDateTile title={MESSAGES.CEREMONY.END_DATE} date={ceremonyDetails.endDate} />
         </div>
+
         <CommonImageList images={ceremonyDetails.imageList} />
+
         <div className="fixed bottom-20 left-0 z-10 flex w-full justify-center gap-5 md:pt-0 lg:gap-11 xl:left-auto xl:w-[calc(100%-29rem)]">
           <CeremonyApprovalButton color="BLUE" onClick={handleClickApprove} text={MESSAGES.CEREMONY.APPROVAL} />
           <CeremonyApprovalButton color="GRAY" onClick={handleClickReject} text={MESSAGES.CEREMONY.REJECTION} />
         </div>
       </div>
-      {isModalOpen && <CeremonyApprovalModal closeModal={closeModal} ceremonyTitle={ceremonyDetails.title} />}
     </>
   );
 };

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyManagement.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyManagement.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 import clsx from 'clsx';
 
-import { useCeremonyData } from '@/fsd_entities/ceremony';
+import { useAdminCeremonyData } from '@/fsd_entities/ceremony';
 
 import { Header, Line, PreviousButton } from '@/fsd_shared';
 
@@ -16,7 +16,7 @@ export const AdminCeremonyManagement = ({
   firstNavigation,
   navigation,
 }: Ceremony.CeremonyRequestManagementProps) => {
-  const { ceremonyList } = useCeremonyData();
+  const ceremonyList = useAdminCeremonyData();
   const isFirstNavigation = (() => {
     if (!state) return true;
     if (!navigation) return false;

--- a/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/shadcn/components/ui';
 import { formatDateInput } from '@/utils';
 
 import { categoryOptions } from '../config/ceremonyType';
-import { NotificationSettingWidgetAlt } from './NotificationSettingWidgetAlt';
+import { NotificationSettingWidget } from './NotificationSettingWidget';
 
 export const CeremonyCreateWidget = () => {
   const methods = useForm<Ceremony.CreateCeremonyPayload>({
@@ -87,7 +87,7 @@ export const CeremonyCreateWidget = () => {
 
         <div className="flex flex-col gap-2.5">
           <p className="text-xl font-medium">경조사 알림 보낼 학번 설정</p>
-          <NotificationSettingWidgetAlt />
+          <NotificationSettingWidget />
         </div>
 
         <div className="flex flex-col gap-2.5">

--- a/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/shadcn/components/ui';
 import { formatDateInput } from '@/utils';
 
 import { categoryOptions } from '../config/ceremonyType';
+import { NotificationSettingWidgetAlt } from './NotificationSettingWidgetAlt';
 
 export const CeremonyCreateWidget = () => {
   const methods = useForm<Ceremony.CreateCeremonyPayload>({
@@ -82,6 +83,11 @@ export const CeremonyCreateWidget = () => {
             height="h-32"
             width="w-full"
           />
+        </div>
+
+        <div className="flex flex-col gap-2.5">
+          <p className="text-xl font-medium">경조사 알림 보낼 학번 설정</p>
+          <NotificationSettingWidgetAlt />
         </div>
 
         <div className="flex flex-col gap-2.5">

--- a/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
@@ -9,7 +9,7 @@ import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 import { ceremonyTypeMap } from '../config';
 
 export const CeremonyDetailPage = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
-  const { ceremonyDetails } = useCeremonyData(ceremonyId);
+  const ceremonyDetails = useCeremonyData(ceremonyId);
   const router = useRouter();
 
   const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];

--- a/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
@@ -1,18 +1,22 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { cancelCeremonyRegist, CeremonyDateTile, CeremonySectionTitle, useCeremonyData } from '@/fsd_entities/ceremony';
 
 import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 
 import { ceremonyTypeMap } from '../config';
+import { NotificationYearListBox } from './NotificationYearListBox';
 
 export const CeremonyDetailPage = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
   const ceremonyDetails = useCeremonyData(ceremonyId);
   const router = useRouter();
 
   const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];
+  const searchParams = useSearchParams();
+  const hideNotificationYearList = searchParams.get('hideList');
+
   const handleClickReject = async () => {
     try {
       await cancelCeremonyRegist({
@@ -38,6 +42,12 @@ export const CeremonyDetailPage = ({ ceremonyId }: Ceremony.CeremonyDetailPagePr
           <CeremonyDateTile title={MESSAGES.CEREMONY.START_DATE} date={ceremonyDetails.startDate} />
           <CeremonyDateTile title={MESSAGES.CEREMONY.END_DATE} date={ceremonyDetails.endDate} />
         </div>
+        {!hideNotificationYearList && (
+          <>
+            <h1 className="text-lg font-medium md:text-2xl">{MESSAGES.NOTIFICATION.YEAR_LIST}</h1>
+            <NotificationYearListBox />
+          </>
+        )}
 
         <CommonImageList images={ceremonyDetails.imageList} />
         {ceremonyDetails.register === 'AWAIT' && (

--- a/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
@@ -1,28 +1,47 @@
 'use client';
 
+import clsx from 'clsx';
+
 import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
 
 import { Button } from '@/fsd_shared';
 
-export const NotificationSettingWidget = () => {
+interface NotificationSettingWidgetProps {
+  isSettingPage?: boolean;
+}
+export const NotificationSettingWidget = ({ isSettingPage = false }: NotificationSettingWidgetProps) => {
   const { years, setAll, setAllYearsSelected, addYear, removeYear, onSubmit } = useCeremonySettingForm();
 
   return (
-    <div className="flex flex-col items-center gap-16">
-      <div className="flex flex-col items-center md:flex-row md:items-start">
-        <div className="mb-10 text-center md:mr-10 md:mb-0 md:text-left">
-          <p className="mb-3 text-xl font-semibold">경조사 알림을 받을 학번 설정</p>
+    <div className={clsx('flex flex-col gap-16', isSettingPage ? 'items-center' : '')}>
+      <div
+        className={clsx(
+          'flex flex-col',
+          isSettingPage ? 'items-center md:flex-row md:items-start' : 'items-start sm:flex-row',
+        )}
+      >
+        <div
+          className={clsx(
+            'text-center',
+            isSettingPage ? 'mb-10 md:mr-10 md:mb-0 md:text-left' : 'mb-2 max-sm:w-full sm:mr-10 sm:mb-10 sm:text-left',
+          )}
+        >
+          {isSettingPage && <p className="mb-3 text-xl font-semibold">경조사 알림을 받을 학번 설정</p>}
           <div className="mb-2">
-            <AdmissionYearInput onAdd={addYear} disabled={setAll} isSettingPage={true} />
+            <AdmissionYearInput onAdd={addYear} disabled={setAll} isSettingPage={isSettingPage} />
           </div>
-          <p className="mb-2 text-sm text-gray-400">학번 입력 후 추가 버튼을 눌러주세요.</p>
-          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} isSettingPage={true} />
+          <p className={clsx('mb-2 text-sm text-gray-400', isSettingPage ? '' : 'text-start')}>
+            학번 입력 후 추가 버튼을 눌러주세요.
+          </p>
+          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} isSettingPage={isSettingPage} />
         </div>
-        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} isSettingPage={true} />
+        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} isSettingPage={isSettingPage} />
       </div>
-      <Button variant="BLUE" action={onSubmit} className="px-20 py-1 text-lg font-bold">
-        저장
-      </Button>
+      {isSettingPage && (
+        <Button variant="BLUE" action={onSubmit} className="px-20 py-1 text-lg font-bold">
+          저장
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  AdmissionYearInput,
-  AdmissionYearList,
-  AllYearToggle,
-  useCeremonySettingForm,
-} from '@/fsd_entities/ceremony';
+import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
 
 import { Button } from '@/fsd_shared';
 
@@ -18,12 +13,12 @@ export const NotificationSettingWidget = () => {
         <div className="mb-10 text-center md:mr-10 md:mb-0 md:text-left">
           <p className="mb-3 text-xl font-semibold">경조사 알림을 받을 학번 설정</p>
           <div className="mb-2">
-            <AdmissionYearInput onAdd={addYear} disabled={setAll} />
+            <AdmissionYearInput onAdd={addYear} disabled={setAll} isSettingPage={true} />
           </div>
           <p className="mb-2 text-sm text-gray-400">학번 입력 후 추가 버튼을 눌러주세요.</p>
-          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} />
+          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} isSettingPage={true} />
         </div>
-        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} />
+        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} isSettingPage={true} />
       </div>
       <Button variant="BLUE" action={onSubmit} className="px-20 py-1 text-lg font-bold">
         저장

--- a/src/fsd_widgets/ceremony/ui/NotificationSettingWidgetAlt.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationSettingWidgetAlt.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
+
+import { Button } from '@/fsd_shared';
+
+interface NotificationSettingWidgetAltProps {
+  view?: boolean;
+}
+export const NotificationSettingWidgetAlt = ({ view = false }: NotificationSettingWidgetAltProps) => {
+  const { years, setAll, setAllYearsSelected, addYear, removeYear, onSubmit } = useCeremonySettingForm();
+
+  return (
+    <div className="flex flex-col gap-16">
+      <div className="flex flex-col items-start sm:flex-row sm:items-start">
+        <div className="mb-2 text-center max-sm:w-full sm:mr-10 sm:mb-10 sm:text-left">
+          <div className="mb-2">
+            <AdmissionYearInput onAdd={addYear} disabled={setAll} />
+          </div>
+          <p className="mb-2 text-start text-sm text-gray-400">학번 입력 후 추가 버튼을 눌러주세요.</p>
+          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} />
+        </div>
+        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} />
+      </div>
+    </div>
+  );
+};

--- a/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
@@ -2,12 +2,7 @@
 
 import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
 
-import { Button } from '@/fsd_shared';
-
-interface NotificationSettingWidgetAltProps {
-  view?: boolean;
-}
-export const NotificationSettingWidgetAlt = ({ view = false }: NotificationSettingWidgetAltProps) => {
+export const NotificationYearListBox = () => {
   const { years, setAll, setAllYearsSelected, addYear, removeYear, onSubmit } = useCeremonySettingForm();
 
   return (

--- a/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
@@ -1,22 +1,21 @@
 'use client';
 
-import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
+import { useCeremonySettingForm } from '@/fsd_entities/ceremony';
 
 export const NotificationYearListBox = () => {
-  const { years, setAll, setAllYearsSelected, addYear, removeYear, onSubmit } = useCeremonySettingForm();
+  const { years } = useCeremonySettingForm();
 
   return (
-    <div className="flex flex-col gap-16">
-      <div className="flex flex-col items-start sm:flex-row sm:items-start">
-        <div className="mb-2 text-center max-sm:w-full sm:mr-10 sm:mb-10 sm:text-left">
-          <div className="mb-2">
-            <AdmissionYearInput onAdd={addYear} disabled={setAll} />
-          </div>
-          <p className="mb-2 text-start text-sm text-gray-400">학번 입력 후 추가 버튼을 눌러주세요.</p>
-          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} />
-        </div>
-        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} />
-      </div>
+    <div className="h-40 w-full overflow-y-auto rounded-xl border border-black bg-white p-5 sm:max-w-85">
+      {years.map((year) => (
+        <button
+          key={year}
+          type="button"
+          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-left text-xl hover:bg-gray-100"
+        >
+          <span>{year}학번</span>
+        </button>
+      ))}
     </div>
   );
 };

--- a/src/fsd_widgets/ceremony/ui/index.ts
+++ b/src/fsd_widgets/ceremony/ui/index.ts
@@ -6,3 +6,4 @@ export { AdminCeremonyList } from './AdminCeremonyList';
 export { AdminCeremonyDetail } from './AdminCeremonyDetail';
 export { NotificationSettingWidget } from './NotificationSettingWidget';
 export { CeremonyTabs } from './CeremonyTabs';
+export { NotificationYearListBox } from './NotificationYearListBox';


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호

📋 PR Checklist

- 경조사 상세에 토스트 에러 뜨는 이슈 해결하기
- 경조사 신청 모달 제목 api 변경 적용
- 관리자 > 신청된 경조사 상세 & 경조사 신청 & 내 경조사 상세 : 경조사 알릴 학번 UI 추가
- 관리자 경조사 상세 카테고리 이슈 추가
- 경조사 상세 사진 확대 viewer추가
<img width="528" height="762" alt="스크린샷 2025-07-29 오후 8 00 53" src="https://github.com/user-attachments/assets/25569ac6-da2d-4dac-a749-f58f5d7d1e58" />
<img width="738" height="776" alt="스크린샷 2025-07-29 오후 8 01 06" src="https://github.com/user-attachments/assets/3b218b3c-4b44-4af3-a307-8f57784baa23" />

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
