### PR TITLE
[FEAT] 경조사 알릴 학번 api 추가

### DIFF
--- a/src/app/(causw)/ceremony/[ceremonyId]/page.tsx
+++ b/src/app/(causw)/ceremony/[ceremonyId]/page.tsx
@@ -9,6 +9,7 @@ import { PreviousButton } from '@/fsd_shared';
 
 const OccasionNotificationDetailPage = () => {
   const { ceremonyId } = useParams<{ ceremonyId: string }>();
+
   return (
     <div className="w-full p-6">
       <PreviousButton />

--- a/src/app/(causw)/ceremony/[ceremonyId]/page.tsx
+++ b/src/app/(causw)/ceremony/[ceremonyId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 
 import { CeremonyDetailPage } from '@/fsd_widgets/ceremony';
 
@@ -9,13 +9,15 @@ import { PreviousButton } from '@/fsd_shared';
 
 const OccasionNotificationDetailPage = () => {
   const { ceremonyId } = useParams<{ ceremonyId: string }>();
+  const searchParams = useSearchParams();
+  const context = searchParams.get('context') as 'my' | 'general';
 
   return (
     <div className="w-full p-6">
       <PreviousButton />
       <div className="pt-12">
         <div className="text-2xl font-medium md:text-3xl">{MESSAGES.CEREMONY.CEREMONY_CONTENTS}</div>
-        <CeremonyDetailPage ceremonyId={ceremonyId} />
+        <CeremonyDetailPage ceremonyId={ceremonyId} context={context} />
       </div>
     </div>
   );

--- a/src/app/(causw)/ceremony/setting/page.tsx
+++ b/src/app/(causw)/ceremony/setting/page.tsx
@@ -1,16 +1,15 @@
 'use client';
 
 import { NotificationSettingWidget } from '@/fsd_widgets/ceremony';
+
 import { PreviousButton } from '@/fsd_shared';
 
 export default function NotificationSettingPage() {
   return (
     <div className="relative top-3 left-4 w-[calc(100%-2rem)] pb-12 md:top-14 md:left-14 md:w-[calc(100%-7rem)]">
       <PreviousButton className="mb-8" />
-      <div className="mb-14 text-center text-2xl font-medium md:text-3xl">
-        경조사 알림 설정
-      </div>
-      <NotificationSettingWidget />
+      <div className="mb-14 text-center text-2xl font-medium md:text-3xl">경조사 알림 설정</div>
+      <NotificationSettingWidget isSettingPage={true} />
     </div>
   );
 }

--- a/src/app/(causw)/setting/management/ceremony/[state]/[ceremonyId]/page.tsx
+++ b/src/app/(causw)/setting/management/ceremony/[state]/[ceremonyId]/page.tsx
@@ -17,7 +17,7 @@ const OccasionRequestDetailPage = () => {
         <Header bold big>
           {MESSAGES.CEREMONY.DETAIL_CONTENT_TITLE}
         </Header>
-        <AdminCeremonyDetail ceremonyId={ceremonyId} />
+        <AdminCeremonyDetail ceremonyId={ceremonyId} context="admin" />
       </div>
     </div>
   );

--- a/src/app/(causw)/setting/notification/page.tsx
+++ b/src/app/(causw)/setting/notification/page.tsx
@@ -77,7 +77,7 @@ const Notification = () => {
             fetchNextCeremony();
           }
         }}
-        hideNotificationYearList={true}
+        context="general"
       />
     ),
   };

--- a/src/app/(causw)/setting/notification/page.tsx
+++ b/src/app/(causw)/setting/notification/page.tsx
@@ -1,19 +1,14 @@
 'use client';
 
 import { NotificationActionButtons, NotificationTabs } from '@/fsd_widgets/notification';
+
 import {
   useCeremonyNotificationQuery,
   useNotificationQuery,
   useNotificationTabParam,
 } from '@/fsd_entities/notification';
 
-import {
-  ERROR_MESSAGES,
-  ListBox,
-  MESSAGES,
-  NOTIFICATION_TAB,
-  PreviousButton,
-} from '@/fsd_shared';
+import { ERROR_MESSAGES, ListBox, MESSAGES, NOTIFICATION_TAB, PreviousButton } from '@/fsd_shared';
 
 import BellIcon from '../../../../../public/icons/bell_icon.svg';
 
@@ -82,6 +77,7 @@ const Notification = () => {
             fetchNextCeremony();
           }
         }}
+        hideNotificationYearList={true}
       />
     ),
   };

--- a/src/app/(causw)/setting/page.tsx
+++ b/src/app/(causw)/setting/page.tsx
@@ -37,18 +37,6 @@ const SettingsPage = () => {
     isGraduate: state.isGraduate,
   }));
 
-  console.log(
-    roles,
-    isAdmin(),
-    isPresidents(),
-    isVicePresidents(),
-    isCircleLeader(),
-    isCouncil(),
-    isStudentLeader(),
-    isAlumniLeader(),
-    isGraduate(),
-  );
-
   const circleIdIfLeader = useMyInfoStore((state) => state.circleIdIfLeader);
   const circleNameIfLeader = useMyInfoStore((state) => state.circleNameIfLeader);
   const [isUseTermsOpen, setIsUseTermsOpen] = useState(false);

--- a/src/fsd_entities/ceremony/api/get.ts
+++ b/src/fsd_entities/ceremony/api/get.ts
@@ -5,13 +5,11 @@ import { API } from '@/fsd_shared';
 
 const CEREMONY_URI = '/api/v1/ceremony';
 
-export const getAdminCeremonyAwaitList = async (page: number, size: number, sort?: string[]) => {
+export const getAdminCeremonyAwaitList = async (page: number) => {
   const URI = `/api/v1/ceremony/list/await`;
 
   const params = {
-    page: page.toString(),
-    size: size.toString(),
-    ...(sort && { sort: sort.join(',') }),
+    pageNum: page.toString(),
   };
 
   try {
@@ -20,7 +18,7 @@ export const getAdminCeremonyAwaitList = async (page: number, size: number, sort
     if (response.status !== 200) {
       throw new Error(`Error: ${response.status}`);
     }
-    return response.data?.content?.length ? response.data.content : [];
+    return response.data;
   } catch (error) {
     if (isAxiosError(error)) {
       toast.error('Axios error:', error.response?.data);

--- a/src/fsd_entities/ceremony/api/get.ts
+++ b/src/fsd_entities/ceremony/api/get.ts
@@ -31,8 +31,8 @@ export const getAdminCeremonyAwaitList = async (page: number, size: number, sort
   }
 };
 
-export const getAdminCeremonyDetail = async (idx: string) => {
-  const URI = `/api/v1/ceremony/${idx}`;
+export const getAdminCeremonyDetail = async ({ ceremonyId, context }: Ceremony.CeremonyDetailDataPros) => {
+  const URI = `/api/v1/ceremony/${ceremonyId}?context=${context}`;
 
   try {
     const response = await API.get(URI);

--- a/src/fsd_entities/ceremony/model/index.ts
+++ b/src/fsd_entities/ceremony/model/index.ts
@@ -1,3 +1,4 @@
-export { useCeremonyData } from './useAdminCeremonyData';
+export { useAdminCeremonyData } from './useAdminCeremonyData';
 export { useCeremonyCreateForm } from './useCeremonyCreateForm';
 export { useCeremonySettingForm } from './useCeremonySettingForm';
+export { useCeremonyData } from './useCeremonyDetailData';

--- a/src/fsd_entities/ceremony/model/useAdminCeremonyData.ts
+++ b/src/fsd_entities/ceremony/model/useAdminCeremonyData.ts
@@ -8,12 +8,15 @@ import { ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 
 import { getAdminCeremonyAwaitList, getAdminCeremonyDetail } from '../api';
 
-export const useAdminCeremonyData = () => {
+interface useAdminCeremonyDataProps {
+  pageNum: number;
+}
+export const useAdminCeremonyData = ({ pageNum = 0 }: useAdminCeremonyDataProps) => {
   const [ceremonyList, setCeremonyList] = useState<Ceremony.CeremonyItem[]>([]);
 
   const fetchCeremonyList = async () => {
     try {
-      const data = await getAdminCeremonyAwaitList(0, 10);
+      const data = await getAdminCeremonyAwaitList(pageNum);
       setCeremonyList(data);
     } catch (error) {
       toast.error(`${MESSAGES.CEREMONY.REGISTRATION_LIST} - ${ERROR_MESSAGES.LIST_FETCH_FAIL}`);

--- a/src/fsd_entities/ceremony/model/useAdminCeremonyData.ts
+++ b/src/fsd_entities/ceremony/model/useAdminCeremonyData.ts
@@ -8,19 +8,9 @@ import { ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 
 import { getAdminCeremonyAwaitList, getAdminCeremonyDetail } from '../api';
 
-export const useCeremonyData = (ceremonyId?: string) => {
+export const useAdminCeremonyData = () => {
   const [ceremonyList, setCeremonyList] = useState<Ceremony.CeremonyItem[]>([]);
-  const [ceremonyDetails, setCeremonyDetails] = useState({
-    title: '',
-    type: '',
-    register: '',
-    content: '',
-    startDate: '',
-    endDate: '',
-    imageList: [] as string[],
-    applicantName: '',
-    applicantStudentId: '',
-  });
+
   const fetchCeremonyList = async () => {
     try {
       const data = await getAdminCeremonyAwaitList(0, 10);
@@ -34,32 +24,5 @@ export const useCeremonyData = (ceremonyId?: string) => {
     fetchCeremonyList();
   }, []);
 
-  useEffect(() => {
-    if (ceremonyId) {
-      const fetchCeremonyDetail = async () => {
-        try {
-          const cermonyContent = await getAdminCeremonyDetail(ceremonyId);
-          const matchedCeremony = ceremonyList.find((item) => item.id === ceremonyId);
-
-          setCeremonyDetails({
-            title: matchedCeremony ? matchedCeremony.title : cermonyContent.description,
-            type: cermonyContent.category,
-            register: cermonyContent.ceremonyState,
-            content: cermonyContent.description,
-            startDate: cermonyContent.startDate,
-            endDate: cermonyContent.endDate,
-            imageList: cermonyContent.attachedImageUrlList,
-            applicantName: cermonyContent.applicantName,
-            applicantStudentId: cermonyContent.applicantStudentId,
-          });
-        } catch (error) {
-          toast.error(`${MESSAGES.CEREMONY.DETAIL_CONTENT_TITLE} - ${ERROR_MESSAGES.DETAIL_CONTENT_FETCH_FAIL}`);
-        }
-      };
-
-      fetchCeremonyDetail();
-    }
-  }, [ceremonyId, ceremonyList]);
-
-  return { ceremonyList, ceremonyDetails };
+  return ceremonyList;
 };

--- a/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
+++ b/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
@@ -26,10 +26,9 @@ export const useCeremonyData = (ceremonyId?: string) => {
       const fetchCeremonyDetail = async () => {
         try {
           const cermonyContent = await getAdminCeremonyDetail(ceremonyId);
-          // const matchedCeremony = ceremonyList.find((item) => item.id === ceremonyId);
 
           setCeremonyDetails({
-            title: '결혼',
+            title: cermonyContent.title,
             type: cermonyContent.category,
             register: cermonyContent.ceremonyState,
             content: cermonyContent.description,

--- a/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
+++ b/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import toast from 'react-hot-toast';
+
+import { ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
+
+import { getAdminCeremonyDetail } from '../api';
+
+export const useCeremonyData = (ceremonyId?: string) => {
+  const [ceremonyDetails, setCeremonyDetails] = useState({
+    title: '',
+    type: '',
+    register: '',
+    content: '',
+    startDate: '',
+    endDate: '',
+    imageList: [] as string[],
+    applicantName: '',
+    applicantStudentId: '',
+  });
+
+  useEffect(() => {
+    if (ceremonyId) {
+      const fetchCeremonyDetail = async () => {
+        try {
+          const cermonyContent = await getAdminCeremonyDetail(ceremonyId);
+          // const matchedCeremony = ceremonyList.find((item) => item.id === ceremonyId);
+
+          setCeremonyDetails({
+            title: '결혼',
+            type: cermonyContent.category,
+            register: cermonyContent.ceremonyState,
+            content: cermonyContent.description,
+            startDate: cermonyContent.startDate,
+            endDate: cermonyContent.endDate,
+            imageList: cermonyContent.attachedImageUrlList,
+            applicantName: cermonyContent.applicantName,
+            applicantStudentId: cermonyContent.applicantStudentId,
+          });
+        } catch (error) {
+          toast.error(`${MESSAGES.CEREMONY.DETAIL_CONTENT_TITLE} - ${ERROR_MESSAGES.DETAIL_CONTENT_FETCH_FAIL}`);
+        }
+      };
+
+      fetchCeremonyDetail();
+    }
+  }, [ceremonyId]);
+
+  return ceremonyDetails;
+};

--- a/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
+++ b/src/fsd_entities/ceremony/model/useCeremonyDetailData.ts
@@ -8,7 +8,7 @@ import { ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 
 import { getAdminCeremonyDetail } from '../api';
 
-export const useCeremonyData = (ceremonyId?: string) => {
+export const useCeremonyData = ({ context, ceremonyId }: Ceremony.CeremonyDetailDataPros) => {
   const [ceremonyDetails, setCeremonyDetails] = useState({
     title: '',
     type: '',
@@ -19,13 +19,15 @@ export const useCeremonyData = (ceremonyId?: string) => {
     imageList: [] as string[],
     applicantName: '',
     applicantStudentId: '',
+    isSetAll: false,
+    targetAdmissionYears: [] as number[],
   });
 
   useEffect(() => {
     if (ceremonyId) {
       const fetchCeremonyDetail = async () => {
         try {
-          const cermonyContent = await getAdminCeremonyDetail(ceremonyId);
+          const cermonyContent = await getAdminCeremonyDetail({ ceremonyId, context });
 
           setCeremonyDetails({
             title: cermonyContent.title,
@@ -37,6 +39,8 @@ export const useCeremonyData = (ceremonyId?: string) => {
             imageList: cermonyContent.attachedImageUrlList,
             applicantName: cermonyContent.applicantName,
             applicantStudentId: cermonyContent.applicantStudentId,
+            isSetAll: cermonyContent.isSetAll,
+            targetAdmissionYears: cermonyContent.targetAdmissionYears,
           });
         } catch (error) {
           toast.error(`${MESSAGES.CEREMONY.DETAIL_CONTENT_TITLE} - ${ERROR_MESSAGES.DETAIL_CONTENT_FETCH_FAIL}`);

--- a/src/fsd_entities/ceremony/model/useCeremonySettingForm.ts
+++ b/src/fsd_entities/ceremony/model/useCeremonySettingForm.ts
@@ -2,21 +2,21 @@
 
 import { useEffect, useMemo, useState } from 'react';
 
-import { useCeremonySettingQuery, useCeremonySettingMutation } from '@/fsd_entities/notification';
+import { useCeremonySettingMutation, useCeremonySettingQuery } from '@/fsd_entities/notification';
 
-export const useCeremonySettingForm = () => {
+export const useCeremonySettingForm = (useExistingSetting = true) => {
   const { data: existingSetting } = useCeremonySettingQuery();
-  const isUpdate = !!(existingSetting && typeof existingSetting !== 'string');
+  const isUpdate = useExistingSetting && !!(existingSetting && typeof existingSetting !== 'string');
   const { mutate: submitSettings } = useCeremonySettingMutation(isUpdate);
   const [years, setYears] = useState<number[]>([]);
   const [setAll, setSetAllValue] = useState(false);
 
   useEffect(() => {
-    if (isUpdate) {
+    if (useExistingSetting && isUpdate) {
       setYears(existingSetting.subscribedAdmissionYears ?? []);
       setSetAllValue(existingSetting.setAll);
     }
-  }, [existingSetting, isUpdate]);
+  }, [existingSetting, isUpdate, useExistingSetting]);
 
   const sortedYears = useMemo(() => {
     return [...years].sort((a, b) => a - b);
@@ -40,7 +40,10 @@ export const useCeremonySettingForm = () => {
     };
     submitSettings(payload);
   };
-
+  const reset = () => {
+    setYears([]);
+    setSetAllValue(false);
+  };
   return {
     years: setAll ? [] : sortedYears,
     setAll,
@@ -48,5 +51,6 @@ export const useCeremonySettingForm = () => {
     addYear,
     removeYear,
     onSubmit,
+    reset,
   };
 };

--- a/src/fsd_entities/ceremony/ui/AdmissionYearInput.tsx
+++ b/src/fsd_entities/ceremony/ui/AdmissionYearInput.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from 'react';
 
+import clsx from 'clsx';
+
 import { Button } from '@/fsd_shared';
 
-export const AdmissionYearInput = ({ onAdd, disabled }: Ceremony.AdmissionYearInputProps) => {
+export const AdmissionYearInput = ({ onAdd, disabled, isSettingPage = false }: Ceremony.AdmissionYearInputProps) => {
   const [year, setYear] = useState('');
 
   const handleAdd = () => {
@@ -21,10 +23,13 @@ export const AdmissionYearInput = ({ onAdd, disabled }: Ceremony.AdmissionYearIn
         type="number"
         value={year}
         onChange={(e) => setYear(e.target.value)}
-        className="w-10 border-b border-b-black bg-transparent px-1"
+        className={clsx(
+          'border-b border-b-black bg-transparent px-1',
+          isSettingPage ? 'w-10 border-b border-b-black bg-transparent px-1' : 'w-13 text-2xl',
+        )}
         disabled={disabled}
       />
-      <span className="mr-14 text-2xl">학번</span>
+      <span className={clsx(isSettingPage ? 'mr-14 text-2xl' : 'mr-9 text-xl')}>학번</span>
       <Button
         variant="BLUE"
         action={handleAdd}

--- a/src/fsd_entities/ceremony/ui/AdmissionYearList.tsx
+++ b/src/fsd_entities/ceremony/ui/AdmissionYearList.tsx
@@ -1,18 +1,30 @@
 'use client';
 
-export const AdmissionYearList = ({ years, onRemove, isAllSelected }: Ceremony.AdmissionYearListProps) => {
+import clsx from 'clsx';
+
+export const AdmissionYearList = ({
+  years,
+  onRemove,
+  isAllSelected,
+  isSettingPage = false,
+}: Ceremony.AdmissionYearListProps) => {
   return (
     <div
-      className={`h-72 w-72 overflow-y-auto rounded-xl border border-black p-5 ${
-        isAllSelected ? 'bg-gray-200' : 'bg-white'
-      }`}
+      className={clsx(
+        'overflow-y-auto rounded-xl border border-black p-5',
+        isAllSelected ? 'bg-gray-200' : 'bg-white',
+        isSettingPage ? 'h-72 w-72' : 'h-40 w-full sm:max-w-85',
+      )}
     >
       {years.map((year) => (
         <button
           key={year}
           onClick={() => onRemove(year)}
           type="button"
-          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-left hover:bg-gray-100"
+          className={clsx(
+            'flex w-full cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-left hover:bg-gray-100',
+            isSettingPage ? '' : 'text-xl',
+          )}
         >
           <span>{year}학번</span>
           <div className="h-0.5 w-4 scale-150 transform rounded-2xl bg-black"></div>

--- a/src/fsd_entities/ceremony/ui/AllYearToggle.tsx
+++ b/src/fsd_entities/ceremony/ui/AllYearToggle.tsx
@@ -1,10 +1,19 @@
 'use client';
 
-export const AllYearToggle = ({ checked, onChange }: Ceremony.AllYearToggleProps) => {
+import clsx from 'clsx';
+
+export const AllYearToggle = ({ checked, onChange, isSettingPage }: Ceremony.AllYearToggleProps) => {
   return (
-    <label className="flex items-center gap-2">
-      <span className="text-lg">모든 학번의 경조사 알림 받기</span>
-      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} className="h-5 w-5" />
+    <label className={clsx('flex items-center', isSettingPage ? 'gap-2' : 'gap-1')}>
+      <span className={clsx(isSettingPage ? 'text-lg' : 'ml-auto text-[15px]')}>
+        {isSettingPage ? '모든 학번의 경조사 알림 받기' : '모든 학번에게 알림 전송'}
+      </span>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className={clsx(isSettingPage ? 'h-5 w-5' : 'h-4 w-4')}
+      />
     </label>
   );
 };

--- a/src/fsd_entities/notification/hooks/queries/ceremonyQueryKey.ts
+++ b/src/fsd_entities/notification/hooks/queries/ceremonyQueryKey.ts
@@ -4,4 +4,5 @@ export const ceremonyQueryKey = {
   all: ['ceremonies'] as const,
   list: (state: CeremonyState) => [...ceremonyQueryKey.all, 'list', state] as const,
   setting: () => [...ceremonyQueryKey.all, 'setting'] as const,
+  awaitList: () => [...ceremonyQueryKey.all, 'awaitList'] as const,
 };

--- a/src/fsd_entities/notification/hooks/queries/useAdminCeremonyAwaitListQuery.ts
+++ b/src/fsd_entities/notification/hooks/queries/useAdminCeremonyAwaitListQuery.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { getAdminCeremonyAwaitList } from '@/fsd_entities/ceremony';
+
+import { ceremonyQueryKey } from './ceremonyQueryKey';
+
+export const useAdminCeremonyAwaitListQuery = () => {
+  return useInfiniteQuery({
+    queryKey: ceremonyQueryKey.awaitList(),
+    queryFn: ({ pageParam = 0 }) => getAdminCeremonyAwaitList(pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      return lastPage.last ? undefined : lastPage.number + 1;
+    },
+    select: (data) => data.pages.flatMap((page) => page.content),
+  });
+};

--- a/src/fsd_shared/@types/ceremony.ts
+++ b/src/fsd_shared/@types/ceremony.ts
@@ -59,6 +59,7 @@ declare namespace Ceremony {
     firstNavigation: NavigationItem;
     navigation?: NavigationItem[];
     state: string | undefined;
+    loadMore: () => void;
   };
   interface CeremonyDetailPageProps {
     ceremonyId: string;

--- a/src/fsd_shared/@types/ceremony.ts
+++ b/src/fsd_shared/@types/ceremony.ts
@@ -1,6 +1,7 @@
 declare namespace Ceremony {
   interface CeremonyDetailPageProps {
     ceremonyId: string;
+    context: 'my' | 'general' | 'admin';
   }
   interface CreateCeremonyRequestDto {
     description: string;
@@ -109,7 +110,7 @@ declare namespace Ceremony {
     alarm?: string; //general | ceremony
     loadMore?: () => void;
     emptyMessage?: string;
-    hideNotificationYearList?: boolean;
+    context?: 'my' | 'general';
   }
   interface CreateCeremonyPayload {
     description: string;
@@ -172,5 +173,12 @@ declare namespace Ceremony {
     subscribedAdmissionYears: number[] | null;
     setAll: boolean;
     notificationActive: boolean;
+  }
+  interface NotificationYearListBoxProps {
+    years: number[];
+  }
+  interface CeremonyDetailDataPros {
+    ceremonyId?: string;
+    context: string;
   }
 }

--- a/src/fsd_shared/@types/ceremony.ts
+++ b/src/fsd_shared/@types/ceremony.ts
@@ -109,6 +109,7 @@ declare namespace Ceremony {
     alarm?: string; //general | ceremony
     loadMore?: () => void;
     emptyMessage?: string;
+    hideNotificationYearList?: boolean;
   }
   interface CreateCeremonyPayload {
     description: string;

--- a/src/fsd_shared/@types/ceremony.ts
+++ b/src/fsd_shared/@types/ceremony.ts
@@ -149,15 +149,18 @@ declare namespace Ceremony {
   interface AdmissionYearInputProps {
     onAdd: (year: number) => void;
     disabled: boolean;
+    isSettingPage?: boolean;
   }
   interface AdmissionYearListProps {
     years: number[];
     onRemove: (year: number) => void;
     isAllSelected?: boolean;
+    isSettingPage?: boolean;
   }
   interface AllYearToggleProps {
     checked: boolean;
     onChange: (val: boolean) => void;
+    isSettingPage?: boolean;
   }
   interface CeremonyNotificationSettingDto {
     subscribedAdmissionYears: number[] | null;

--- a/src/fsd_shared/@types/ceremony.ts
+++ b/src/fsd_shared/@types/ceremony.ts
@@ -177,6 +177,7 @@ declare namespace Ceremony {
   }
   interface NotificationYearListBoxProps {
     years: number[];
+    isSetAll: boolean;
   }
   interface CeremonyDetailDataPros {
     ceremonyId?: string;

--- a/src/fsd_shared/configs/constants/messages.ts
+++ b/src/fsd_shared/configs/constants/messages.ts
@@ -20,5 +20,6 @@ export const MESSAGES = Object.freeze({
     ALL: '전체 알림',
     GENERAL: '알림',
     CEREMONY: '경조사',
+    YEAR_LIST: '경조사 알림 대상 학번',
   },
 });

--- a/src/fsd_shared/ui/CommonImageList.tsx
+++ b/src/fsd_shared/ui/CommonImageList.tsx
@@ -23,7 +23,7 @@ export const CommonImageList = ({ images }: CommonImageListProps) => {
     setIsViewerOpen(false);
     setSelectedIndex(null);
   };
-
+  if (images.length === 0) return;
   return (
     <div className="flex flex-col gap-2">
       <h1 className="text-lg font-bold md:text-2xl">사진</h1>

--- a/src/fsd_shared/ui/ListBox.tsx
+++ b/src/fsd_shared/ui/ListBox.tsx
@@ -9,10 +9,9 @@ import { useInfiniteScroll } from '@/fsd_shared/hooks/useInfiniteScroll';
 import MailIcon from '../../../public/icons/envelope_icon.svg';
 import MailOpendIcon from '../../../public/icons/envelope_open_icon.svg';
 
-export const ListBox = ({ data, alarm, loadMore, emptyMessage }: Ceremony.ListBoxProps) => {
+export const ListBox = ({ data, alarm, loadMore, emptyMessage, hideNotificationYearList }: Ceremony.ListBoxProps) => {
   const router = useRouter();
   const markAsRead = useNotificationStore((state) => state.markAsRead);
-
   const { targetRef } = useInfiniteScroll({
     intersectionCallback: ([entry]) => {
       if (entry.isIntersecting && loadMore) {
@@ -25,7 +24,7 @@ export const ListBox = ({ data, alarm, loadMore, emptyMessage }: Ceremony.ListBo
     <div className="max-h-[calc(100vh-22rem)] max-w-[560px] overflow-y-auto rounded-lg bg-[#D9D9D9] p-4 md:max-h-[calc(100vh-25rem)] xl:max-h-[calc(100vh-17rem)]">
       <div className="flex max-h-full flex-col space-y-4">
         {data.length === 0 ? (
-          <div className="flex h-20 items-center justify-center">{emptyMessage || "목록이 없습니다."}</div>
+          <div className="flex h-20 items-center justify-center">{emptyMessage || '목록이 없습니다.'}</div>
         ) : (
           data.map((item, index) => {
             const isItemRead = item.isRead ?? true;
@@ -34,8 +33,8 @@ export const ListBox = ({ data, alarm, loadMore, emptyMessage }: Ceremony.ListBo
               alarm === 'general'
                 ? `/board/${item.targetParentId}/${item.targetId}`
                 : item.targetId
-                  ? `/ceremony/${item.targetId}`
-                  : `/ceremony/${item.id}`;
+                  ? `/ceremony/${item.targetId}${hideNotificationYearList ? '?hideList=true' : ''}`
+                  : `/ceremony/${item.id}${hideNotificationYearList ? '?hideList=true' : ''}`;
             return (
               <div
                 onClick={() => {
@@ -61,9 +60,7 @@ export const ListBox = ({ data, alarm, loadMore, emptyMessage }: Ceremony.ListBo
                   />
                 )}
 
-                <div className="text-gray-600">
-                  {isItemRead ? <MailOpendIcon size={32} /> : <MailIcon size={32} />}
-                </div>
+                <div className="text-gray-600">{isItemRead ? <MailOpendIcon size={32} /> : <MailIcon size={32} />}</div>
                 <div className="text-left">
                   <div className="font-medium text-[#212323]">{item.title}</div>
                   <div className="text-sm text-[#212323]">{item.body}</div>

--- a/src/fsd_shared/ui/ListBox.tsx
+++ b/src/fsd_shared/ui/ListBox.tsx
@@ -9,7 +9,7 @@ import { useInfiniteScroll } from '@/fsd_shared/hooks/useInfiniteScroll';
 import MailIcon from '../../../public/icons/envelope_icon.svg';
 import MailOpendIcon from '../../../public/icons/envelope_open_icon.svg';
 
-export const ListBox = ({ data, alarm, loadMore, emptyMessage, hideNotificationYearList }: Ceremony.ListBoxProps) => {
+export const ListBox = ({ data, alarm, loadMore, emptyMessage, context }: Ceremony.ListBoxProps) => {
   const router = useRouter();
   const markAsRead = useNotificationStore((state) => state.markAsRead);
   const { targetRef } = useInfiniteScroll({
@@ -33,8 +33,8 @@ export const ListBox = ({ data, alarm, loadMore, emptyMessage, hideNotificationY
               alarm === 'general'
                 ? `/board/${item.targetParentId}/${item.targetId}`
                 : item.targetId
-                  ? `/ceremony/${item.targetId}${hideNotificationYearList ? '?hideList=true' : ''}`
-                  : `/ceremony/${item.id}${hideNotificationYearList ? '?hideList=true' : ''}`;
+                  ? `/ceremony/${item.targetId}?context=${context}`
+                  : `/ceremony/${item.id}?context=${context}`;
             return (
               <div
                 onClick={() => {

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -74,7 +74,7 @@ export const AdminCeremonyDetail = ({ ceremonyId, context }: Ceremony.CeremonyDe
         </div>
 
         <h1 className="text-lg font-medium md:text-2xl">{MESSAGES.NOTIFICATION.YEAR_LIST}</h1>
-        <NotificationYearListBox years={ceremonyDetails.targetAdmissionYears} />
+        <NotificationYearListBox years={ceremonyDetails.targetAdmissionYears} isSetAll={ceremonyDetails.isSetAll} />
 
         <CommonImageList images={ceremonyDetails.imageList} />
 

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -21,8 +21,9 @@ import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 import { ceremonyTypeMap } from '../config';
 
 export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
-  const { ceremonyDetails } = useCeremonyData(ceremonyId);
+  const ceremonyDetails = useCeremonyData(ceremonyId);
   const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];
+
   const router = useRouter();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const closeModal = () => {

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -19,6 +19,7 @@ import {
 import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 
 import { ceremonyTypeMap } from '../config';
+import { NotificationYearListBox } from './NotificationYearListBox';
 
 export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
   const ceremonyDetails = useCeremonyData(ceremonyId);
@@ -70,6 +71,9 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
           <CeremonyDateTile title={MESSAGES.CEREMONY.START_DATE} date={ceremonyDetails.startDate} />
           <CeremonyDateTile title={MESSAGES.CEREMONY.END_DATE} date={ceremonyDetails.endDate} />
         </div>
+
+        <h1 className="text-lg font-medium md:text-2xl">{MESSAGES.NOTIFICATION.YEAR_LIST}</h1>
+        <NotificationYearListBox />
 
         <CommonImageList images={ceremonyDetails.imageList} />
 

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -16,11 +16,13 @@ import {
   CeremonySectionTitle,
 } from '@/fsd_entities/ceremony';
 
-import { ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
+import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
+
+import { ceremonyTypeMap } from '../config';
 
 export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
   const { ceremonyDetails } = useCeremonyData(ceremonyId);
-
+  const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];
   const router = useRouter();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const closeModal = () => {
@@ -54,7 +56,7 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
     <>
       <div className="flex flex-col gap-3 pt-8 pb-10 md:gap-6">
         <div className="grid grid-cols-1 gap-3 md:gap-8 lg:grid-cols-2 lg:gap-32">
-          <CeremonySectionTitle title={MESSAGES.CEREMONY.CATEGORY} ceremonyContent={ceremonyDetails.type} />
+          <CeremonySectionTitle title={MESSAGES.CEREMONY.CATEGORY} ceremonyContent={ceremonyType} />
           <CeremonySectionTitle
             title={MESSAGES.CEREMONY.REGISTRANT}
             ceremonyContent={`${ceremonyDetails.applicantName}/${ceremonyDetails.applicantStudentId}`}
@@ -65,7 +67,7 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
           <CeremonyDateTile title={MESSAGES.CEREMONY.START_DATE} date={ceremonyDetails.startDate} />
           <CeremonyDateTile title={MESSAGES.CEREMONY.END_DATE} date={ceremonyDetails.endDate} />
         </div>
-        <CeremonyImageTile imageList={ceremonyDetails.imageList} />
+        <CommonImageList images={ceremonyDetails.imageList} />
         <div className="fixed bottom-20 left-0 z-10 flex w-full justify-center gap-5 md:pt-0 lg:gap-11 xl:left-auto xl:w-[calc(100%-29rem)]">
           <CeremonyApprovalButton color="BLUE" onClick={handleClickApprove} text={MESSAGES.CEREMONY.APPROVAL} />
           <CeremonyApprovalButton color="GRAY" onClick={handleClickReject} text={MESSAGES.CEREMONY.REJECTION} />

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -21,8 +21,8 @@ import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 import { ceremonyTypeMap } from '../config';
 import { NotificationYearListBox } from './NotificationYearListBox';
 
-export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
-  const ceremonyDetails = useCeremonyData(ceremonyId);
+export const AdminCeremonyDetail = ({ ceremonyId, context }: Ceremony.CeremonyDetailPageProps) => {
+  const ceremonyDetails = useCeremonyData({ ceremonyId, context });
   const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];
 
   const router = useRouter();
@@ -35,6 +35,7 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
     try {
       await updateAdminCeremonyState({
         ceremonyId,
+
         targetCeremonyState: 'ACCEPT',
       });
       setIsModalOpen(true);
@@ -73,7 +74,7 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
         </div>
 
         <h1 className="text-lg font-medium md:text-2xl">{MESSAGES.NOTIFICATION.YEAR_LIST}</h1>
-        <NotificationYearListBox />
+        <NotificationYearListBox years={ceremonyDetails.targetAdmissionYears} />
 
         <CommonImageList images={ceremonyDetails.imageList} />
 

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyDetail.tsx
@@ -55,6 +55,8 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
 
   return (
     <>
+      {isModalOpen && <CeremonyApprovalModal closeModal={closeModal} ceremonyTitle={ceremonyDetails.title} />}
+
       <div className="flex flex-col gap-3 pt-8 pb-10 md:gap-6">
         <div className="grid grid-cols-1 gap-3 md:gap-8 lg:grid-cols-2 lg:gap-32">
           <CeremonySectionTitle title={MESSAGES.CEREMONY.CATEGORY} ceremonyContent={ceremonyType} />
@@ -68,13 +70,14 @@ export const AdminCeremonyDetail = ({ ceremonyId }: Ceremony.CeremonyDetailPageP
           <CeremonyDateTile title={MESSAGES.CEREMONY.START_DATE} date={ceremonyDetails.startDate} />
           <CeremonyDateTile title={MESSAGES.CEREMONY.END_DATE} date={ceremonyDetails.endDate} />
         </div>
+
         <CommonImageList images={ceremonyDetails.imageList} />
+
         <div className="fixed bottom-20 left-0 z-10 flex w-full justify-center gap-5 md:pt-0 lg:gap-11 xl:left-auto xl:w-[calc(100%-29rem)]">
           <CeremonyApprovalButton color="BLUE" onClick={handleClickApprove} text={MESSAGES.CEREMONY.APPROVAL} />
           <CeremonyApprovalButton color="GRAY" onClick={handleClickReject} text={MESSAGES.CEREMONY.REJECTION} />
         </div>
       </div>
-      {isModalOpen && <CeremonyApprovalModal closeModal={closeModal} ceremonyTitle={ceremonyDetails.title} />}
     </>
   );
 };

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyList.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyList.tsx
@@ -1,21 +1,44 @@
 import Link from 'next/link';
 
-export const AdminCeremonyList = ({ list, firstNavigation, navigation, state }: Ceremony.CeremonyListProps) => {
+import { useInfiniteScroll } from '@/fsd_shared';
+
+export const AdminCeremonyList = ({
+  list,
+  firstNavigation,
+  navigation,
+  state,
+  loadMore,
+}: Ceremony.CeremonyListProps) => {
+  const { targetRef } = useInfiniteScroll({
+    intersectionCallback: ([entry]) => {
+      if (entry.isIntersecting && loadMore) {
+        loadMore();
+      }
+    },
+  });
+
   return (
     <div className="mt-6 ml-2 flex flex-col">
-      {list.map((element: Ceremony.CeremonyItem) => (
-        <Link
-          href={
-            (firstNavigation ? firstNavigation.router : navigation!.find((el: any) => el.state === state)?.router) +
-            '/' +
-            element.id
-          }
-          className="mb-3 text-lg"
-          key={element.id}
-        >
-          {element.title}
-        </Link>
-      ))}
+      {list.length > 0 ? (
+        <>
+          {list.map((element: Ceremony.CeremonyItem) => (
+            <Link
+              href={
+                (firstNavigation ? firstNavigation.router : navigation?.find((el: any) => el.state === state)?.router) +
+                '/' +
+                element.id
+              }
+              className="mb-3 text-lg"
+              key={element.id}
+            >
+              {element.title}
+            </Link>
+          ))}
+          <div ref={targetRef} className="h-[1px]" />
+        </>
+      ) : (
+        <div>신청된 경조사가 없습니다.</div>
+      )}
     </div>
   );
 };

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyManagement.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyManagement.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 import clsx from 'clsx';
 
-import { useCeremonyData } from '@/fsd_entities/ceremony';
+import { useAdminCeremonyData } from '@/fsd_entities/ceremony';
 
 import { Header, Line, PreviousButton } from '@/fsd_shared';
 
@@ -16,7 +16,7 @@ export const AdminCeremonyManagement = ({
   firstNavigation,
   navigation,
 }: Ceremony.CeremonyRequestManagementProps) => {
-  const { ceremonyList } = useCeremonyData();
+  const ceremonyList = useAdminCeremonyData();
   const isFirstNavigation = (() => {
     if (!state) return true;
     if (!navigation) return false;

--- a/src/fsd_widgets/ceremony/ui/AdminCeremonyManagement.tsx
+++ b/src/fsd_widgets/ceremony/ui/AdminCeremonyManagement.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 import clsx from 'clsx';
 
-import { useAdminCeremonyData } from '@/fsd_entities/ceremony';
+import { useAdminCeremonyAwaitListQuery } from '@/fsd_entities/notification/hooks/queries/useAdminCeremonyAwaitListQuery';
 
 import { Header, Line, PreviousButton } from '@/fsd_shared';
 
@@ -16,7 +16,7 @@ export const AdminCeremonyManagement = ({
   firstNavigation,
   navigation,
 }: Ceremony.CeremonyRequestManagementProps) => {
-  const ceremonyList = useAdminCeremonyData();
+  const { data: ceremonyList = [], fetchNextPage, hasNextPage, isFetchingNextPage } = useAdminCeremonyAwaitListQuery();
   const isFirstNavigation = (() => {
     if (!state) return true;
     if (!navigation) return false;
@@ -55,6 +55,9 @@ export const AdminCeremonyManagement = ({
           firstNavigation={firstNavigation}
           navigation={navigation}
           state={state}
+          loadMore={() => {
+            if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+          }}
         />
       </div>
     </div>

--- a/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/shadcn/components/ui';
 import { formatDateInput } from '@/utils';
 
 import { categoryOptions } from '../config/ceremonyType';
-import { NotificationSettingWidgetAlt } from './NotificationSettingWidgetAlt';
+import { NotificationSettingWidget } from './NotificationSettingWidget';
 
 export const CeremonyCreateWidget = () => {
   const methods = useForm<Ceremony.CreateCeremonyPayload>({
@@ -87,7 +87,7 @@ export const CeremonyCreateWidget = () => {
 
         <div className="flex flex-col gap-2.5">
           <p className="text-xl font-medium">경조사 알림 보낼 학번 설정</p>
-          <NotificationSettingWidgetAlt />
+          <NotificationSettingWidget />
         </div>
 
         <div className="flex flex-col gap-2.5">

--- a/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/shadcn/components/ui';
 import { formatDateInput } from '@/utils';
 
 import { categoryOptions } from '../config/ceremonyType';
+import { NotificationSettingWidgetAlt } from './NotificationSettingWidgetAlt';
 
 export const CeremonyCreateWidget = () => {
   const methods = useForm<Ceremony.CreateCeremonyPayload>({
@@ -82,6 +83,11 @@ export const CeremonyCreateWidget = () => {
             height="h-32"
             width="w-full"
           />
+        </div>
+
+        <div className="flex flex-col gap-2.5">
+          <p className="text-xl font-medium">경조사 알림 보낼 학번 설정</p>
+          <NotificationSettingWidgetAlt />
         </div>
 
         <div className="flex flex-col gap-2.5">

--- a/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyCreateWidget.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { useCeremonyCreateForm } from '@/fsd_entities/ceremony';
+import { useCeremonyCreateForm, useCeremonySettingForm } from '@/fsd_entities/ceremony';
 
 import { ImageUploadField, InputBox, SelectBox } from '@/fsd_shared';
 import { Button } from '@/shadcn/components/ui';
@@ -25,10 +25,17 @@ export const CeremonyCreateWidget = () => {
   });
 
   const { onSubmit } = useCeremonyCreateForm();
+  const settingForm = useCeremonySettingForm(false);
   const [resetImageUploader, setResetImageUploader] = useState(false);
   const handleFormSubmit = methods.handleSubmit(async (data) => {
-    onSubmit(data);
+    const fullPayload = {
+      ...data,
+      isSetAll: settingForm.setAll,
+      targetAdmissionYears: settingForm.setAll ? null : settingForm.years,
+    };
+    onSubmit(fullPayload);
     methods.reset();
+    settingForm.reset();
     setResetImageUploader(true);
     setTimeout(() => setResetImageUploader(false), 0);
   });
@@ -87,7 +94,13 @@ export const CeremonyCreateWidget = () => {
 
         <div className="flex flex-col gap-2.5">
           <p className="text-xl font-medium">경조사 알림 보낼 학번 설정</p>
-          <NotificationSettingWidget />
+          <NotificationSettingWidget
+            years={settingForm.years}
+            setAll={settingForm.setAll}
+            addYear={settingForm.addYear}
+            removeYear={settingForm.removeYear}
+            setAllYearsSelected={settingForm.setAllYearsSelected}
+          />
         </div>
 
         <div className="flex flex-col gap-2.5">

--- a/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
@@ -43,7 +43,7 @@ export const CeremonyDetailPage = ({ ceremonyId, context }: Ceremony.CeremonyDet
         {context !== 'general' && (
           <>
             <h1 className="text-lg font-medium md:text-2xl">{MESSAGES.NOTIFICATION.YEAR_LIST}</h1>
-            <NotificationYearListBox years={ceremonyDetails.targetAdmissionYears} />
+            <NotificationYearListBox years={ceremonyDetails.targetAdmissionYears} isSetAll={ceremonyDetails.isSetAll} />
           </>
         )}
 

--- a/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
@@ -9,13 +9,11 @@ import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 import { ceremonyTypeMap } from '../config';
 import { NotificationYearListBox } from './NotificationYearListBox';
 
-export const CeremonyDetailPage = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
-  const ceremonyDetails = useCeremonyData(ceremonyId);
+export const CeremonyDetailPage = ({ ceremonyId, context }: Ceremony.CeremonyDetailPageProps) => {
+  const ceremonyDetails = useCeremonyData({ ceremonyId, context });
   const router = useRouter();
 
   const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];
-  const searchParams = useSearchParams();
-  const hideNotificationYearList = searchParams.get('hideList');
 
   const handleClickReject = async () => {
     try {
@@ -42,10 +40,10 @@ export const CeremonyDetailPage = ({ ceremonyId }: Ceremony.CeremonyDetailPagePr
           <CeremonyDateTile title={MESSAGES.CEREMONY.START_DATE} date={ceremonyDetails.startDate} />
           <CeremonyDateTile title={MESSAGES.CEREMONY.END_DATE} date={ceremonyDetails.endDate} />
         </div>
-        {!hideNotificationYearList && (
+        {context !== 'general' && (
           <>
             <h1 className="text-lg font-medium md:text-2xl">{MESSAGES.NOTIFICATION.YEAR_LIST}</h1>
-            <NotificationYearListBox />
+            <NotificationYearListBox years={ceremonyDetails.targetAdmissionYears} />
           </>
         )}
 

--- a/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
@@ -9,7 +9,7 @@ import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 import { ceremonyTypeMap } from '../config';
 
 export const CeremonyDetailPage = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
-  const { ceremonyDetails } = useCeremonyData(ceremonyId);
+  const ceremonyDetails = useCeremonyData(ceremonyId);
   const router = useRouter();
 
   const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];

--- a/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyDetailPage.tsx
@@ -1,18 +1,22 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import { cancelCeremonyRegist, CeremonyDateTile, CeremonySectionTitle, useCeremonyData } from '@/fsd_entities/ceremony';
 
 import { CommonImageList, ERROR_MESSAGES, MESSAGES } from '@/fsd_shared';
 
 import { ceremonyTypeMap } from '../config';
+import { NotificationYearListBox } from './NotificationYearListBox';
 
 export const CeremonyDetailPage = ({ ceremonyId }: Ceremony.CeremonyDetailPageProps) => {
   const ceremonyDetails = useCeremonyData(ceremonyId);
   const router = useRouter();
 
   const ceremonyType = ceremonyTypeMap[ceremonyDetails.type];
+  const searchParams = useSearchParams();
+  const hideNotificationYearList = searchParams.get('hideList');
+
   const handleClickReject = async () => {
     try {
       await cancelCeremonyRegist({
@@ -38,6 +42,12 @@ export const CeremonyDetailPage = ({ ceremonyId }: Ceremony.CeremonyDetailPagePr
           <CeremonyDateTile title={MESSAGES.CEREMONY.START_DATE} date={ceremonyDetails.startDate} />
           <CeremonyDateTile title={MESSAGES.CEREMONY.END_DATE} date={ceremonyDetails.endDate} />
         </div>
+        {!hideNotificationYearList && (
+          <>
+            <h1 className="text-lg font-medium md:text-2xl">{MESSAGES.NOTIFICATION.YEAR_LIST}</h1>
+            <NotificationYearListBox />
+          </>
+        )}
 
         <CommonImageList images={ceremonyDetails.imageList} />
         {ceremonyDetails.register === 'AWAIT' && (

--- a/src/fsd_widgets/ceremony/ui/CeremonyListWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/CeremonyListWidget.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from 'react';
 
+import { CeremonyTabs } from '@/fsd_widgets/ceremony';
+
 import { useCeremonyListQuery } from '@/fsd_entities/notification';
 
 import { ListBox } from '@/fsd_shared';
 
 import { tabItems } from '../config';
-import { CeremonyTabs } from '@/fsd_widgets/ceremony';
 
 export const CeremonyListWidget = () => {
   const [activeTab, setActiveTab] = useState(0);
@@ -26,6 +27,7 @@ export const CeremonyListWidget = () => {
       <CeremonyTabs tabItems={tabItems} activeTab={activeTab} setActiveTab={setActiveTab} />
       <div className="mt-4">
         <ListBox
+          context="my"
           data={items}
           loadMore={() => {
             if (hasNextPage && !isFetchingNextPage) {

--- a/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
@@ -8,36 +8,63 @@ import { Button } from '@/fsd_shared';
 
 interface NotificationSettingWidgetProps {
   isSettingPage?: boolean;
+  years?: number[];
+  setAll?: boolean;
+  addYear?: (year: number) => void;
+  removeYear?: (year: number) => void;
+  setAllYearsSelected?: (value: boolean) => void;
+  onSubmit?: () => void;
 }
-export const NotificationSettingWidget = ({ isSettingPage = false }: NotificationSettingWidgetProps) => {
-  const { years, setAll, setAllYearsSelected, addYear, removeYear, onSubmit } = useCeremonySettingForm();
+export const NotificationSettingWidget = (props: NotificationSettingWidgetProps) => {
+  const {
+    years: internalYears,
+    setAll: internalSetAll,
+    addYear: internalAddYear,
+    removeYear: internalRemoveYear,
+    setAllYearsSelected: internalSetAllYearsSelected,
+    onSubmit: internalOnSubmit,
+  } = useCeremonySettingForm();
+
+  const years = props.years ?? internalYears;
+  const setAll = props.setAll ?? internalSetAll;
+  const addYear = props.addYear ?? internalAddYear;
+  const removeYear = props.removeYear ?? internalRemoveYear;
+  const setAllYearsSelected = props.setAllYearsSelected ?? internalSetAllYearsSelected;
+  const onSubmit = props.onSubmit ?? internalOnSubmit;
 
   return (
-    <div className={clsx('flex flex-col gap-16', isSettingPage ? 'items-center' : '')}>
+    <div className={clsx('flex flex-col gap-16', props.isSettingPage ? 'items-center' : '')}>
       <div
         className={clsx(
           'flex flex-col',
-          isSettingPage ? 'items-center md:flex-row md:items-start' : 'items-start sm:flex-row',
+          props.isSettingPage ? 'items-center md:flex-row md:items-start' : 'items-start sm:flex-row',
         )}
       >
         <div
           className={clsx(
             'text-center',
-            isSettingPage ? 'mb-10 md:mr-10 md:mb-0 md:text-left' : 'mb-2 max-sm:w-full sm:mr-10 sm:mb-10 sm:text-left',
+            props.isSettingPage
+              ? 'mb-10 md:mr-10 md:mb-0 md:text-left'
+              : 'mb-2 max-sm:w-full sm:mr-10 sm:mb-10 sm:text-left',
           )}
         >
-          {isSettingPage && <p className="mb-3 text-xl font-semibold">경조사 알림을 받을 학번 설정</p>}
+          {props.isSettingPage && <p className="mb-3 text-xl font-semibold">경조사 알림을 받을 학번 설정</p>}
           <div className="mb-2">
-            <AdmissionYearInput onAdd={addYear} disabled={setAll} isSettingPage={isSettingPage} />
+            <AdmissionYearInput onAdd={addYear} disabled={setAll} isSettingPage={props.isSettingPage} />
           </div>
-          <p className={clsx('mb-2 text-sm text-gray-400', isSettingPage ? '' : 'text-start')}>
+          <p className={clsx('mb-2 text-sm text-gray-400', props.isSettingPage ? '' : 'text-start')}>
             학번 입력 후 추가 버튼을 눌러주세요.
           </p>
-          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} isSettingPage={isSettingPage} />
+          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} isSettingPage={props.isSettingPage} />
         </div>
-        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} isSettingPage={isSettingPage} />
+        <AdmissionYearList
+          years={years}
+          onRemove={removeYear}
+          isAllSelected={setAll}
+          isSettingPage={props.isSettingPage}
+        />
       </div>
-      {isSettingPage && (
+      {props.isSettingPage && (
         <Button variant="BLUE" action={onSubmit} className="px-20 py-1 text-lg font-bold">
           저장
         </Button>

--- a/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
@@ -1,28 +1,47 @@
 'use client';
 
+import clsx from 'clsx';
+
 import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
 
 import { Button } from '@/fsd_shared';
 
-export const NotificationSettingWidget = () => {
+interface NotificationSettingWidgetProps {
+  isSettingPage?: boolean;
+}
+export const NotificationSettingWidget = ({ isSettingPage = false }: NotificationSettingWidgetProps) => {
   const { years, setAll, setAllYearsSelected, addYear, removeYear, onSubmit } = useCeremonySettingForm();
 
   return (
-    <div className="flex flex-col items-center gap-16">
-      <div className="flex flex-col items-center md:flex-row md:items-start">
-        <div className="mb-10 text-center md:mr-10 md:mb-0 md:text-left">
-          <p className="mb-3 text-xl font-semibold">경조사 알림을 받을 학번 설정</p>
+    <div className={clsx('flex flex-col gap-16', isSettingPage ? 'items-center' : '')}>
+      <div
+        className={clsx(
+          'flex flex-col',
+          isSettingPage ? 'items-center md:flex-row md:items-start' : 'items-start sm:flex-row',
+        )}
+      >
+        <div
+          className={clsx(
+            'text-center',
+            isSettingPage ? 'mb-10 md:mr-10 md:mb-0 md:text-left' : 'mb-2 max-sm:w-full sm:mr-10 sm:mb-10 sm:text-left',
+          )}
+        >
+          {isSettingPage && <p className="mb-3 text-xl font-semibold">경조사 알림을 받을 학번 설정</p>}
           <div className="mb-2">
-            <AdmissionYearInput onAdd={addYear} disabled={setAll} isSettingPage={true} />
+            <AdmissionYearInput onAdd={addYear} disabled={setAll} isSettingPage={isSettingPage} />
           </div>
-          <p className="mb-2 text-sm text-gray-400">학번 입력 후 추가 버튼을 눌러주세요.</p>
-          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} isSettingPage={true} />
+          <p className={clsx('mb-2 text-sm text-gray-400', isSettingPage ? '' : 'text-start')}>
+            학번 입력 후 추가 버튼을 눌러주세요.
+          </p>
+          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} isSettingPage={isSettingPage} />
         </div>
-        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} isSettingPage={true} />
+        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} isSettingPage={isSettingPage} />
       </div>
-      <Button variant="BLUE" action={onSubmit} className="px-20 py-1 text-lg font-bold">
-        저장
-      </Button>
+      {isSettingPage && (
+        <Button variant="BLUE" action={onSubmit} className="px-20 py-1 text-lg font-bold">
+          저장
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationSettingWidget.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  AdmissionYearInput,
-  AdmissionYearList,
-  AllYearToggle,
-  useCeremonySettingForm,
-} from '@/fsd_entities/ceremony';
+import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
 
 import { Button } from '@/fsd_shared';
 
@@ -18,12 +13,12 @@ export const NotificationSettingWidget = () => {
         <div className="mb-10 text-center md:mr-10 md:mb-0 md:text-left">
           <p className="mb-3 text-xl font-semibold">경조사 알림을 받을 학번 설정</p>
           <div className="mb-2">
-            <AdmissionYearInput onAdd={addYear} disabled={setAll} />
+            <AdmissionYearInput onAdd={addYear} disabled={setAll} isSettingPage={true} />
           </div>
           <p className="mb-2 text-sm text-gray-400">학번 입력 후 추가 버튼을 눌러주세요.</p>
-          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} />
+          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} isSettingPage={true} />
         </div>
-        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} />
+        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} isSettingPage={true} />
       </div>
       <Button variant="BLUE" action={onSubmit} className="px-20 py-1 text-lg font-bold">
         저장

--- a/src/fsd_widgets/ceremony/ui/NotificationSettingWidgetAlt.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationSettingWidgetAlt.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
+
+import { Button } from '@/fsd_shared';
+
+interface NotificationSettingWidgetAltProps {
+  view?: boolean;
+}
+export const NotificationSettingWidgetAlt = ({ view = false }: NotificationSettingWidgetAltProps) => {
+  const { years, setAll, setAllYearsSelected, addYear, removeYear, onSubmit } = useCeremonySettingForm();
+
+  return (
+    <div className="flex flex-col gap-16">
+      <div className="flex flex-col items-start sm:flex-row sm:items-start">
+        <div className="mb-2 text-center max-sm:w-full sm:mr-10 sm:mb-10 sm:text-left">
+          <div className="mb-2">
+            <AdmissionYearInput onAdd={addYear} disabled={setAll} />
+          </div>
+          <p className="mb-2 text-start text-sm text-gray-400">학번 입력 후 추가 버튼을 눌러주세요.</p>
+          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} />
+        </div>
+        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} />
+      </div>
+    </div>
+  );
+};

--- a/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
@@ -1,21 +1,21 @@
 'use client';
 
-import { useCeremonySettingForm } from '@/fsd_entities/ceremony';
-
-export const NotificationYearListBox = () => {
-  const { years } = useCeremonySettingForm();
-
+export const NotificationYearListBox = ({ years }: Ceremony.NotificationYearListBoxProps) => {
   return (
     <div className="h-40 w-full overflow-y-auto rounded-xl border border-black bg-white p-5 sm:max-w-85">
-      {years.map((year) => (
-        <button
-          key={year}
-          type="button"
-          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-left text-xl hover:bg-gray-100"
-        >
-          <span>{year}학번</span>
-        </button>
-      ))}
+      {years.length > 0 ? (
+        years.map((year) => (
+          <button
+            key={year}
+            type="button"
+            className="flex w-full cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-left text-xl hover:bg-gray-100"
+          >
+            <span>{year}학번</span>
+          </button>
+        ))
+      ) : (
+        <span>전체 학번</span>
+      )}
     </div>
   );
 };

--- a/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
@@ -2,12 +2,7 @@
 
 import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
 
-import { Button } from '@/fsd_shared';
-
-interface NotificationSettingWidgetAltProps {
-  view?: boolean;
-}
-export const NotificationSettingWidgetAlt = ({ view = false }: NotificationSettingWidgetAltProps) => {
+export const NotificationYearListBox = () => {
   const { years, setAll, setAllYearsSelected, addYear, removeYear, onSubmit } = useCeremonySettingForm();
 
   return (

--- a/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-export const NotificationYearListBox = ({ years }: Ceremony.NotificationYearListBoxProps) => {
+export const NotificationYearListBox = ({ years, isSetAll }: Ceremony.NotificationYearListBoxProps) => {
   return (
     <div className="h-40 w-full overflow-y-auto rounded-xl border border-black bg-white p-5 sm:max-w-85">
-      {years.length > 0 ? (
+      {isSetAll ? (
+        <span className="text-xl">전체 학번</span>
+      ) : years.length > 0 ? (
         years.map((year) => (
           <button
             key={year}
@@ -13,9 +15,7 @@ export const NotificationYearListBox = ({ years }: Ceremony.NotificationYearList
             <span>{year}학번</span>
           </button>
         ))
-      ) : (
-        <span className="text-xl">전체 학번</span>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
@@ -14,7 +14,7 @@ export const NotificationYearListBox = ({ years }: Ceremony.NotificationYearList
           </button>
         ))
       ) : (
-        <span>전체 학번</span>
+        <span className="text-xl">전체 학번</span>
       )}
     </div>
   );

--- a/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
+++ b/src/fsd_widgets/ceremony/ui/NotificationYearListBox.tsx
@@ -1,22 +1,21 @@
 'use client';
 
-import { AdmissionYearInput, AdmissionYearList, AllYearToggle, useCeremonySettingForm } from '@/fsd_entities/ceremony';
+import { useCeremonySettingForm } from '@/fsd_entities/ceremony';
 
 export const NotificationYearListBox = () => {
-  const { years, setAll, setAllYearsSelected, addYear, removeYear, onSubmit } = useCeremonySettingForm();
+  const { years } = useCeremonySettingForm();
 
   return (
-    <div className="flex flex-col gap-16">
-      <div className="flex flex-col items-start sm:flex-row sm:items-start">
-        <div className="mb-2 text-center max-sm:w-full sm:mr-10 sm:mb-10 sm:text-left">
-          <div className="mb-2">
-            <AdmissionYearInput onAdd={addYear} disabled={setAll} />
-          </div>
-          <p className="mb-2 text-start text-sm text-gray-400">학번 입력 후 추가 버튼을 눌러주세요.</p>
-          <AllYearToggle checked={setAll} onChange={setAllYearsSelected} />
-        </div>
-        <AdmissionYearList years={years} onRemove={removeYear} isAllSelected={setAll} />
-      </div>
+    <div className="h-40 w-full overflow-y-auto rounded-xl border border-black bg-white p-5 sm:max-w-85">
+      {years.map((year) => (
+        <button
+          key={year}
+          type="button"
+          className="flex w-full cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-left text-xl hover:bg-gray-100"
+        >
+          <span>{year}학번</span>
+        </button>
+      ))}
     </div>
   );
 };

--- a/src/fsd_widgets/ceremony/ui/index.ts
+++ b/src/fsd_widgets/ceremony/ui/index.ts
@@ -6,3 +6,4 @@ export { AdminCeremonyList } from './AdminCeremonyList';
 export { AdminCeremonyDetail } from './AdminCeremonyDetail';
 export { NotificationSettingWidget } from './NotificationSettingWidget';
 export { CeremonyTabs } from './CeremonyTabs';
+export { NotificationYearListBox } from './NotificationYearListBox';

--- a/src/fsd_widgets/pageLayout/ui/SideBar.tsx
+++ b/src/fsd_widgets/pageLayout/ui/SideBar.tsx
@@ -11,9 +11,11 @@ import { NotificationWidget } from '@/fsd_widgets/notification';
 import { getNotificationCount } from '@/fsd_entities/notification';
 import { useUserInfo } from '@/fsd_entities/user';
 import { useMyInfoStore } from '@/fsd_entities/user';
+
+import { ProfileImage } from '@/fsd_shared/ui';
+
 import { SubHeader, tokenManager } from '@/fsd_shared';
 import { Button } from '@/shadcn/components/ui';
-import { ProfileImage } from '@/fsd_shared/ui';
 
 interface SideBarProps {
   className?: string;
@@ -29,7 +31,6 @@ export const SideBar = ({ className }: SideBarProps) => {
 
   const [alarmCount, setAlarmCount] = useState<number>(0);
   const messageCount: number = 0;
-
 
   useEffect(() => {
     updateMyInfoStore();
@@ -74,7 +75,8 @@ export const SideBar = ({ className }: SideBarProps) => {
         </Link>
       </Button>
 
-      <Button
+      {/* 20250803 기획 중단으로 주석처리 */}
+      {/* <Button
         size="icon"
         variant="ghost"
         className="absolute top-3 left-22 flex cursor-pointer flex-col gap-2 p-0 text-black shadow-none xl:hidden"
@@ -83,7 +85,7 @@ export const SideBar = ({ className }: SideBarProps) => {
         <Link href="/chat">
           <Mail className="size-6" />
         </Link>
-      </Button>
+      </Button> */}
       <div className="max-xl:hidden">
         <ProfileImage src={profileImage} />
       </div>


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호

📋 PR Checklist

- 경조사 상세 보기 쿼리 추가(내 경조사 조회 / 경조사 신청한 유저글 상세 조회(어드민용) / 경조사 알람 상세 용) 반영 및 알림 신청한 학번 노출
- 경조사 등록 신청 api 연동
- 관리자용 경조사 승인대기 목록 무한 스크롤 추가
- 채팅 ui 주석처리

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
