### PR TITLE
[CHORE] 사물함 설명 줄바꿈 방지

### DIFF
--- a/src/fsd_widgets/locker/ui/LockerSelectionMobileManual.tsx
+++ b/src/fsd_widgets/locker/ui/LockerSelectionMobileManual.tsx
@@ -44,11 +44,9 @@ export const LockerSelectionMobileManual = ({ lockerPeriod }: LockerSelectionMob
           })}
         </div>
         <div className="flex justify-end text-end">
-          <div className="w-2/3">
-            <p className="text-sm text-[#888888]">
-              신청 후 다른 사물함으로 재신청하는 경우, <br />
-              원래 사물함은 자동으로 반납 처리 됩니다.
-            </p>
+          <div className="text-sm text-[#888888]">
+            <p className="text-nowrap">신청 후 다른 사물함으로 재신청하는 경우,</p>
+            <p className="text-nowrap">원래 사물함은 자동으로 반납 처리 됩니다.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #240 

📋 PR Checklist

- 모바일 화면에서, 사물함 설명 줄바꿈 이슈 : nowrap 추가함
- 상위 div의 w-2/3 속성은 필요없어서 제거함

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
<img width="417" height="500" alt="image" src="https://github.com/user-attachments/assets/fcec29d8-e90f-4d62-8dfd-f664adf0b096" />
