### PR TITLE
258 fix 4차 qa 수정사항

### DIFF
--- a/src/app/(causw)/home/ClientGraduatePage.tsx
+++ b/src/app/(causw)/home/ClientGraduatePage.tsx
@@ -3,13 +3,6 @@ import Link from 'next/link';
 
 import { Banner, fetchGraduateHomePosts } from '@/fsd_entities/home';
 
-const boards = [
-  { name: '크자회 공지 게시판', icon: '/homeicons/크자회_공지_게시판.svg', href: '/notice' }, // 크자회 공지 게시판 경로 수정 예정
-  { name: '소통 게시판', icon: '/homeicons/크자회_소통_게시판.svg', href: '/talk' }, // 소통 게시판 경로 수정 예정
-  { name: '동문수첩', icon: '/homeicons/동문수첩.svg', href: '/directory' }, // 동문수첩 경로 수정 예정
-  { name: '경조사', icon: '/homeicons/경조사.svg', href: '/ceremony/create' },
-];
-
 export default async function GraduateHomePage({ events }) {
   const homePosts = await fetchGraduateHomePosts();
 
@@ -23,6 +16,22 @@ export default async function GraduateHomePage({ events }) {
 
   const noticeBoardId = noticeBoard?.board.id ?? '';
   const talkBoardId = talkBoard?.board.id ?? '';
+
+  // 📌 API 응답 기반 동적 boards 배열
+  const boards = [
+    {
+      name: '크자회 공지 게시판',
+      icon: '/homeicons/크자회_공지_게시판.svg',
+      href: `/board/${noticeBoardId}`,
+    },
+    {
+      name: '소통 게시판',
+      icon: '/homeicons/크자회_소통_게시판.svg',
+      href: `/board/${talkBoardId}`,
+    },
+    { name: '동문수첩', icon: '/homeicons/동문수첩.svg', href: '/contacts' },
+    { name: '경조사', icon: '/homeicons/경조사.svg', href: '/ceremony/create' },
+  ];
 
   return (
     <div className="flex w-full flex-col justify-center gap-4 bg-white px-4 py-4 2xl:h-full 2xl:rounded-4xl">

--- a/src/app/(causw)/home/ClientPage.tsx
+++ b/src/app/(causw)/home/ClientPage.tsx
@@ -87,10 +87,14 @@ export default async function ClientHomePage({ events }) {
               <p className="h-6 text-[24px] font-bold">🌟 빠른 공지 모아모아 🌟</p>
               <div className="flex h-[calc(100%-24px)] w-full justify-center">
                 <div className="hidden w-2/5 flex-col items-center justify-around border-r border-[rgba(209,209,209,1)] text-xl font-bold md:flex">
-                  <span>❗️ 서비스 공지</span>
-                  <span>📖️ 소프트웨어학부 공지</span>
-                  <span>🌍️ 크자회 공지 게시판</span>
-                  <span>🏆️ 학생회 공지 게시판</span>
+                  {mainBoards.map((board, idx) => (
+                    <Link key={idx} href={`/board/${board?.board.id}`} className="cursor-pointer">
+                      {idx === 0 && '❗️ 서비스 공지'}
+                      {idx === 1 && '📖️ 소프트웨어학부 공지'}
+                      {idx === 2 && '🌍️ 크자회 공지 게시판'}
+                      {idx === 3 && '🏆️ 학생회 공지 게시판'}
+                    </Link>
+                  ))}
                 </div>
 
                 <div className="flex h-80 w-5/6 flex-col items-center justify-around font-bold xl:text-lg 2xl:h-full 2xl:w-3/5">

--- a/src/app/(causw)/home/ClientPage.tsx
+++ b/src/app/(causw)/home/ClientPage.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 import { Calendar } from '@/fsd_widgets/calender';
 
-import { Banner, CardBox, HomeCard, fetchHomePosts } from '@/fsd_entities/home';
+import { Banner, CardBox, fetchHomePosts, HomeCard } from '@/fsd_entities/home';
 
 const cardsEntities = [
   {
@@ -34,7 +34,7 @@ export default async function ClientHomePage({ events }) {
   const mainBoards = [
     homePosts.find((board) => board.board.name.includes('서비스 공지')),
     homePosts.find((board) => board.board.name.includes('학부 공지')),
-    homePosts.find((board) => board.board.name.includes('동문회 공지')),
+    homePosts.find((board) => board.board.name.includes('크자회 공지')),
     homePosts.find((board) => board.board.name.includes('학생회 공지')),
   ];
 
@@ -89,7 +89,7 @@ export default async function ClientHomePage({ events }) {
                 <div className="hidden w-2/5 flex-col items-center justify-around border-r border-[rgba(209,209,209,1)] text-xl font-bold md:flex">
                   <span>❗️ 서비스 공지</span>
                   <span>📖️ 소프트웨어학부 공지</span>
-                  <span>🌍️ 동문회 공지 게시판</span>
+                  <span>🌍️ 크자회 공지 게시판</span>
                   <span>🏆️ 학생회 공지 게시판</span>
                 </div>
 

--- a/src/fsd_entities/auth/config/academicRecordValidation.ts
+++ b/src/fsd_entities/auth/config/academicRecordValidation.ts
@@ -17,8 +17,10 @@ export const academicRecordValidationRules: Record<
     required: '졸업 월을 입력해주세요.',
   },
   note: {
-    required: '특이사항을 작성해주세요.',
-    maxLength: 500,
+    maxLength: {
+      value: 500,
+      message: '500자 이내로 입력해주세요.',
+    },
   },
   images: {
     required: '이미지를 첨부해주세요.',

--- a/src/fsd_entities/auth/config/admissionValidation.ts
+++ b/src/fsd_entities/auth/config/admissionValidation.ts
@@ -8,8 +8,10 @@ export const admissionValidationRules: Record<
     required: '이메일을 입력해주세요',
   },
   description: {
-    required: '특이사항을 작성해주세요.',
-    maxLength: 500,
+    maxLength: {
+      value: 500,
+      message: '500자 이내로 입력해주세요.',
+    },
   },
   attachImage: {
     required: '이미지를 첨부해주세요.',

--- a/src/fsd_entities/board/model/hooks/fetchBoardList.ts
+++ b/src/fsd_entities/board/model/hooks/fetchBoardList.ts
@@ -9,16 +9,15 @@ export const fetchBoardList = async () => {
   });
 
   const priorityOrder = [
+    '서비스 공지',
+    '건의/오류 제보 게시판',
     '크자회 공지 게시판',
     '크자회 소통 게시판',
-    '서비스 공지',
     '학생회 공지 게시판',
     '소프트웨어학부 학부 공지',
-    '건의/오류 제보 게시판',
     '딜리버드 게시판',
   ];
 
-  const excludeFromNonGraduate = ['크자회 공지 게시판', '크자회 소통 게시판'];
   const graduateBoardNames = ['서비스 공지', '크자회 공지 게시판', '크자회 소통 게시판', '건의/오류 제보 게시판'];
 
   const sortedBoardList = [
@@ -29,7 +28,7 @@ export const fetchBoardList = async () => {
   ];
 
   // 일반 사용자 및 관리자에게 보여줄 게시판에서 '크자회' 게시판 제외
-  const nonGraduateBoardList = sortedBoardList.filter((board) => !excludeFromNonGraduate.includes(board.boardName));
+  const nonGraduateBoardList = sortedBoardList;
 
   // 일반/관리자용 게시판
   const defaultBoardForAdmin = nonGraduateBoardList.filter((board) => board.isDefault);

--- a/src/fsd_entities/user/api/delete.ts
+++ b/src/fsd_entities/user/api/delete.ts
@@ -39,14 +39,3 @@ export const deleteUser = async (userId: string) => {
   if (!response.ok) throw new Error(response.statusText);
   return true;
 };
-
-// 사용자 '탈퇴' - SSR 용
-export const withdrawUser = async () => {
-  const headers = await setRscHeader();
-  const response = await fetch(`${BASEURL}${USERS_ENDPOINT}`, {
-    method: 'DELETE',
-    headers,
-  });
-  if (!response.ok) throw new Error(response.statusText);
-  return true;
-};

--- a/src/fsd_entities/user/api/delete.ts
+++ b/src/fsd_entities/user/api/delete.ts
@@ -19,6 +19,12 @@ export const deleteUserCouncilFeeInfo = async (userCouncilFeeId: string) => {
   }
 };
 
+// 사용자 '탈퇴' - 본인 계정 탈퇴 (파라미터 없음, 토큰 필요)
+export const withdrawUserCSR = async () => {
+  const res = await API.delete(`${USERS_ENDPOINT}`);
+  return res.status >= 200 && res.status < 300;
+};
+
 // ssr api method.
 ////////////////////////////////////////////////////////////////
 
@@ -30,6 +36,17 @@ export const deleteUser = async (userId: string) => {
     headers: headers,
   });
 
+  if (!response.ok) throw new Error(response.statusText);
+  return true;
+};
+
+// 사용자 '탈퇴' - SSR 용
+export const withdrawUser = async () => {
+  const headers = await setRscHeader();
+  const response = await fetch(`${BASEURL}${USERS_ENDPOINT}`, {
+    method: 'DELETE',
+    headers,
+  });
   if (!response.ok) throw new Error(response.statusText);
   return true;
 };

--- a/src/fsd_shared/ui/UseTerms.tsx
+++ b/src/fsd_shared/ui/UseTerms.tsx
@@ -1,21 +1,43 @@
 'use client';
 
+import { useState } from 'react';
+
+import { withdrawUserCSR } from '@/fsd_entities/user';
+
+import { tokenManager } from '../utils';
+
 interface UseTermsProps {
   closeModal: () => void;
 }
 
 export const UseTerms = ({ closeModal }: UseTermsProps) => {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const { signoutAndRedirect } = tokenManager();
+
+  const handleDeleteAccount = async () => {
+    try {
+      await withdrawUserCSR();
+      signoutAndRedirect();
+    } catch (e) {
+    } finally {
+      closeModal();
+    }
+  };
+
   return (
     <div
-      className="bg-opacity-50 fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black"
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/50"
       onClick={closeModal}
     >
-      <div className="h-5/6 w-5/6 max-w-3xl overflow-y-auto rounded-lg bg-white p-8">
+      <div
+        className="h-5/6 w-5/6 max-w-3xl overflow-y-auto rounded-lg bg-white p-8"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div>
           <>
             <div title="이용 약관" />
             <div className="">
-              <div className="">
+              <div className="mb-6">
                 <h2 className="mb-6 flex justify-center text-lg font-bold">서비스 이용약관</h2>
                 <h1 />
                 제1조(목적)
@@ -464,16 +486,55 @@ export const UseTerms = ({ closeModal }: UseTermsProps) => {
                 <br />
                 5. 개인정보 제공 거부 시 불이익 : 서비스 이용 제한
               </div>
+
+              <div className="flex w-full flex-col items-center gap-4">
+                {/* 닫기 버튼 */}
+                <button
+                  onClick={closeModal}
+                  className="bg-focus mt-4 rounded-lg px-4 py-2 text-white hover:bg-blue-400"
+                >
+                  닫기
+                </button>
+
+                {/* 회원 탈퇴 버튼 */}
+                <button
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="rounded-lg bg-red-500 px-4 py-2 text-white hover:bg-red-600"
+                >
+                  회원 탈퇴
+                </button>
+              </div>
+
+              {/* 탈퇴 확인 모달 */}
+              {showDeleteConfirm && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90">
+                  <div className="w-96 rounded-lg bg-white p-6 shadow-lg">
+                    <p className="mb-6 text-center text-lg font-semibold">
+                      정말 탈퇴하시겠습니까? <br />
+                      회원정보는 이용약관에 따라 탈퇴 처리됩니다.
+                    </p>
+                    <div className="flex justify-center gap-4">
+                      <button
+                        onClick={() => setShowDeleteConfirm(false)}
+                        className="rounded-lg bg-gray-300 px-4 py-2 hover:bg-gray-400"
+                      >
+                        취소
+                      </button>
+                      <button
+                        onClick={handleDeleteAccount}
+                        className="rounded-lg bg-red-500 px-4 py-2 text-white hover:bg-red-600"
+                      >
+                        확인
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
             <div className="mt-4 ml-4 flex items-center">
               <label htmlFor="terms"></label>
             </div>
           </>
-        </div>
-        <div className="flex w-full items-center justify-center">
-          <button onClick={closeModal} className="bg-focus mt-4 rounded-lg px-4 py-2 text-white hover:bg-blue-400">
-            닫기
-          </button>
         </div>
       </div>
     </div>

--- a/src/fsd_shared/ui/UseTerms.tsx
+++ b/src/fsd_shared/ui/UseTerms.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import toast from 'react-hot-toast';
+
 import { withdrawUserCSR } from '@/fsd_entities/user';
 
 import { tokenManager } from '../utils';
@@ -19,6 +21,7 @@ export const UseTerms = ({ closeModal }: UseTermsProps) => {
       await withdrawUserCSR();
       signoutAndRedirect();
     } catch (e) {
+      toast.error('회원 탈퇴 실패: 잠시 후 다시 시도해주세요.');
     } finally {
       closeModal();
     }

--- a/src/fsd_widgets/auth/ui/AcademicRecordForm.tsx
+++ b/src/fsd_widgets/auth/ui/AcademicRecordForm.tsx
@@ -83,8 +83,8 @@ export const AcademicRecordForm = ({ curAcademicStatus, onClose, rejectionReason
         <InfoTextArea
           register={register}
           name="note"
-          label="유저 작성 특이사항"
-          placeholder="(선택) 특이사항을 작성해주세요. (500자 이내)"
+          label="유저 작성 특이사항 (선택사항)"
+          placeholder="특이사항을 작성해주세요. (500자 이내)"
           rules={academicRecordValidationRules.note}
           errorMessage={errors.note?.message}
         />

--- a/src/fsd_widgets/auth/ui/AcademicRecordForm.tsx
+++ b/src/fsd_widgets/auth/ui/AcademicRecordForm.tsx
@@ -84,7 +84,7 @@ export const AcademicRecordForm = ({ curAcademicStatus, onClose, rejectionReason
           register={register}
           name="note"
           label="유저 작성 특이사항"
-          placeholder="특이사항을 작성해주세요. (500자 이내)"
+          placeholder="(선택) 특이사항을 작성해주세요. (500자 이내)"
           rules={academicRecordValidationRules.note}
           errorMessage={errors.note?.message}
         />

--- a/src/fsd_widgets/auth/ui/AdmissionForm.tsx
+++ b/src/fsd_widgets/auth/ui/AdmissionForm.tsx
@@ -25,8 +25,8 @@ export const AdmissionForm = () => {
       <InfoTextArea
         register={register}
         name="description"
-        label="유저 작성 특이사항"
-        placeholder="(선택) 특이사항을 작성해주세요. (500자 이내)"
+        label="유저 작성 특이사항 (선택사항)"
+        placeholder="특이사항을 작성해주세요. (500자 이내)"
         rules={admissionValidationRules.description}
         errorMessage={errors.description?.message}
       />

--- a/src/fsd_widgets/auth/ui/AdmissionForm.tsx
+++ b/src/fsd_widgets/auth/ui/AdmissionForm.tsx
@@ -26,7 +26,7 @@ export const AdmissionForm = () => {
         register={register}
         name="description"
         label="유저 작성 특이사항"
-        placeholder="특이사항을 작성해주세요. (500자 이내)"
+        placeholder="(선택) 특이사항을 작성해주세요. (500자 이내)"
         rules={admissionValidationRules.description}
         errorMessage={errors.description?.message}
       />


### PR DESCRIPTION

🚩 관련 이슈
ex) resolve #258 

📋 PR Checklist

- 회원 탈퇴 기능
- 가입신청서/증빙서류제출 특이사항 선택으로 변경
- 재학생 홈 화면 UI에서 크자회 관련 게시판 라우팅
- 크자회 메인 페이지 그리드 선택 시 페이지 라우팅

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
| 회원탈퇴 버튼(iPhone 12 Pro) | 회원탈퇴 버튼(PC) |
| --- | --- |
| <img width="1170" height="2532" alt="localhost_3000_setting(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/09e557f6-c031-4ba2-986b-46734d51698a" /> | <img width="3840" height="2160" alt="localhost_3000_setting" src="https://github.com/user-attachments/assets/580861c1-cd15-4a56-af44-432bc9208219" /> |

| 회원탈퇴 버튼 클릭 시(PC) | 회원탈퇴 버튼 클릭 시(iPhone 12 Pro) |
| --- | --- |
| <img width="3840" height="2160" alt="localhost_3000_setting (1)" src="https://github.com/user-attachments/assets/a34849a4-c4e0-4c7e-aad7-5d0bb24ca7b0" /> | <img width="1170" height="2532" alt="localhost_3000_setting(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/0d0ccbb2-f59c-4372-aa1c-adca8968796b" /> |

| 재학생 홈화면(PC) | 재학생 게시판 화면(PC) |
| --- | --- |
| <img width="3840" height="2160" alt="localhost_3000_auth_signin" src="https://github.com/user-attachments/assets/13cf64e9-1b1f-4278-a3aa-44ee62837249" /> | <img width="3840" height="2160" alt="localhost_3000_auth_signin (1)" src="https://github.com/user-attachments/assets/4e9ccb68-bc71-4911-80bf-4bebd47b5d31" /> |

