### PR TITLE
[FIX] 졸업생 전용 게시판 목록 화면 전체 불러오기

### DIFF
--- a/src/fsd_entities/board/model/hooks/fetchBoardList.ts
+++ b/src/fsd_entities/board/model/hooks/fetchBoardList.ts
@@ -18,8 +18,6 @@ export const fetchBoardList = async () => {
     '딜리버드 게시판',
   ];
 
-  const graduateBoardNames = ['서비스 공지', '크자회 공지 게시판', '크자회 소통 게시판', '건의/오류 제보 게시판'];
-
   const sortedBoardList = [
     ...boardList
       .filter((board) => priorityOrder.includes(board.boardName))
@@ -27,26 +25,14 @@ export const fetchBoardList = async () => {
     ...boardList.filter((board) => !priorityOrder.includes(board.boardName)),
   ];
 
-  // 일반 사용자 및 관리자에게 보여줄 게시판에서 '크자회' 게시판 제외
-  const nonGraduateBoardList = sortedBoardList;
-
   // 일반/관리자용 게시판
-  const defaultBoardForAdmin = nonGraduateBoardList.filter((board) => board.isDefault);
-  const defaultBoardForCommon = nonGraduateBoardList.filter(
+  const defaultBoardForAdmin = sortedBoardList.filter((board) => board.isDefault);
+  const defaultBoardForCommon = sortedBoardList.filter(
     (board) => board.isDefault && !boardInfoMap.get(board.boardId)?.isDeleted,
   );
-  const customBoardForAdmin = nonGraduateBoardList.filter((board) => !board.isDefault);
-  const customBoardForCommon = nonGraduateBoardList.filter(
+  const customBoardForAdmin = sortedBoardList.filter((board) => !board.isDefault);
+  const customBoardForCommon = sortedBoardList.filter(
     (board) => !board.isDefault && !boardInfoMap.get(board.boardId)?.isDeleted,
-  );
-
-  // 졸업생 전용 게시판 (크자회 포함된 고정 목록)
-  const defaultBoardForGraduate = sortedBoardList.filter(
-    (board) =>
-      board.isDefault && !boardInfoMap.get(board.boardId)?.isDeleted && graduateBoardNames.includes(board.boardName),
-  );
-  const customBoardForGraduate = sortedBoardList.filter(
-    (board) => !board.isDefault && graduateBoardNames.includes(board.boardName),
   );
 
   return {
@@ -55,7 +41,5 @@ export const fetchBoardList = async () => {
     defaultBoardForCommon,
     customBoardForAdmin,
     customBoardForCommon,
-    defaultBoardForGraduate,
-    customBoardForGraduate,
   };
 };

--- a/src/fsd_widgets/board/ui/BoardList/BoardList.tsx
+++ b/src/fsd_widgets/board/ui/BoardList/BoardList.tsx
@@ -5,15 +5,8 @@ import { BoardListClient } from './BoardListClient';
 
 export const BoardList = async () => {
   const roles = await getMyRoles();
-  const {
-    defaultBoardForAdmin,
-    defaultBoardForCommon,
-    customBoardForAdmin,
-    customBoardForCommon,
-    defaultBoardForGraduate,
-    customBoardForGraduate,
-    sortedBoardList,
-  } = await fetchBoardList();
+  const { defaultBoardForAdmin, defaultBoardForCommon, customBoardForAdmin, customBoardForCommon } =
+    await fetchBoardList();
 
   return (
     <BoardListClient
@@ -22,9 +15,6 @@ export const BoardList = async () => {
       defaultBoardForCommon={defaultBoardForCommon}
       customBoardForAdmin={customBoardForAdmin}
       customBoardForCommon={customBoardForCommon}
-      defaultBoardForGraduate={defaultBoardForGraduate}
-      customBoardForGraduate={customBoardForGraduate}
-      sortedBoardList={sortedBoardList}
     />
   );
 };

--- a/src/fsd_widgets/board/ui/BoardList/BoardListClient.tsx
+++ b/src/fsd_widgets/board/ui/BoardList/BoardListClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 
 import Link from 'next/link';
 
-import { useUserAcademic, isGraduate } from '@/fsd_entities/user';
+import { isGraduate, useUserAcademic } from '@/fsd_entities/user';
 
 import { CustomBoard } from './CustomBoard';
 import { DefaultNoticeBoard } from './DefaultNoticeBoard';
@@ -15,9 +15,6 @@ export const BoardListClient = ({
   defaultBoardForCommon,
   customBoardForAdmin,
   customBoardForCommon,
-  defaultBoardForGraduate,
-  customBoardForGraduate,
-  sortedBoardList,
 }) => {
   const { data: userInfo } = useUserAcademic();
   const isGraduated = userInfo ? isGraduate(userInfo.academicStatus) : false;
@@ -27,15 +24,6 @@ export const BoardListClient = ({
   if (!mounted) return null;
 
   const renderBoard = () => {
-    if (isGraduated) {
-      return (
-        <>
-          <DefaultNoticeBoard boardInfos={defaultBoardForGraduate} />
-          <CustomBoard boardInfos={customBoardForGraduate} />
-        </>
-      );
-    }
-
     if (roles.includes('ADMIN')) {
       return (
         <>


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #266 

📋 PR Checklist

- 졸업생 전용 게시판 목록에 해당하는 게시판 모두 불러오기

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
<img width="300" alt="localhost_3000_auth_signin(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/a512b232-6b07-40b2-9aeb-59546949b484" /> <img width="300" alt="localhost_3000_auth_signin(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/42ad6a16-fd24-4a63-9f39-d0bbf61a8037" />
