### PR TITLE
[FEAT]탈퇴한 회원 복구 기능

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -11,7 +11,7 @@ import toast from 'react-hot-toast';
 
 import { SignInFooter } from '@/fsd_widgets/auth';
 
-import { SignInInput, SignInSubmitButton } from '@/fsd_entities/auth';
+import { SignInInput, SignInSubmitButton, useRecoverAccount } from '@/fsd_entities/auth';
 import { useLogin } from '@/fsd_entities/auth/model/hooks/useLogin';
 import { usePushNotification } from '@/fsd_entities/notification/model/usePushNotification';
 
@@ -31,15 +31,16 @@ const routes = [
 const SignInPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const handleOpenModal = () => {
-    console.log('됐니');
     setIsModalOpen(true);
   };
 
   const router = useRouter();
   const login = useLogin({ onDeletedAccount: handleOpenModal });
+  const { mutate: recoverAccountMutate } = useRecoverAccount();
+
   const { compareFCMToken } = usePushNotification();
 
-  const { register, handleSubmit, control } = useForm<User.SignInRequestDto>({
+  const { register, handleSubmit, control, watch } = useForm<User.SignInRequestDto>({
     defaultValues: {
       email: '',
       password: '',
@@ -70,6 +71,15 @@ const SignInPage = () => {
       navigator.serviceWorker.register('/firebase-messaging-sw.js').then((registration) => {});
     }
   }, []);
+
+  const formEmail = watch('email');
+
+  const handleRecover = () => {
+    if (formEmail) {
+      recoverAccountMutate({ email: formEmail });
+      setIsModalOpen(false);
+    }
+  };
   return (
     <>
       {isModalOpen && (
@@ -81,10 +91,8 @@ const SignInPage = () => {
           subTitle="계정 복구를 진행하시겠습니까?"
           topBtnLabel="닫기"
           BottomBtnLabel="복구"
-          bottomBtnOnClick={() => {}}
-        >
-          <p>dd</p>
-        </ActionModal>
+          bottomBtnOnClick={handleRecover}
+        />
       )}
       <div className="mx-auto flex h-screen w-full max-w-[502px] flex-1 flex-col items-center justify-between gap-5 px-8 py-18 sm:px-5">
         <div className="flex w-full flex-col items-center gap-1.5 sm:gap-3">
@@ -96,7 +104,7 @@ const SignInPage = () => {
               style={{ objectFit: 'contain' }}
               priority
             />
-          </div>{' '}
+          </div>
           <div className="font-pretendard text-xs font-normal sm:text-2xl sm:font-medium">
             함께라면 더 밝은 미래로, 우리들의
           </div>

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,24 +1,25 @@
 'use client';
-import '@/firebase-messaging-sw';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
 import { Controller } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
+import toast from 'react-hot-toast';
 
 import { SignInFooter } from '@/fsd_widgets/auth';
 
 import { SignInInput, SignInSubmitButton } from '@/fsd_entities/auth';
-import { Switch } from '@/shadcn/components/ui';
-
-import { emailRegex, getRccRefresh } from '@/fsd_shared';
-import toast from 'react-hot-toast';
 import { useLogin } from '@/fsd_entities/auth/model/hooks/useLogin';
 import { usePushNotification } from '@/fsd_entities/notification/model/usePushNotification';
 
+import { ActionModal } from '@/fsd_shared/ui/ActionModal';
+
+import '@/firebase-messaging-sw';
+import { emailRegex, getRccRefresh } from '@/fsd_shared';
+import { Switch } from '@/shadcn/components/ui';
 
 const routes = [
   { name: '아이디찾기', route: '/auth/findemail' },
@@ -28,8 +29,14 @@ const routes = [
 ];
 
 const SignInPage = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const handleOpenModal = () => {
+    console.log('됐니');
+    setIsModalOpen(true);
+  };
+
   const router = useRouter();
-  const login = useLogin();
+  const login = useLogin({ onDeletedAccount: handleOpenModal });
   const { compareFCMToken } = usePushNotification();
 
   const { register, handleSubmit, control } = useForm<User.SignInRequestDto>({
@@ -65,6 +72,20 @@ const SignInPage = () => {
   }, []);
   return (
     <>
+      {isModalOpen && (
+        <ActionModal
+          closeModal={() => {
+            setIsModalOpen(false);
+          }}
+          headTitle="탈퇴한 유저입니다"
+          subTitle="계정 복구를 진행하시겠습니까?"
+          topBtnLabel="닫기"
+          BottomBtnLabel="복구"
+          bottomBtnOnClick={() => {}}
+        >
+          <p>dd</p>
+        </ActionModal>
+      )}
       <div className="mx-auto flex h-screen w-full max-w-[502px] flex-1 flex-col items-center justify-between gap-5 px-8 py-18 sm:px-5">
         <div className="flex w-full flex-col items-center gap-1.5 sm:gap-3">
           <div className="relative h-[34px] w-[250px] sm:h-[68px] sm:w-[500px]">
@@ -76,14 +97,10 @@ const SignInPage = () => {
               priority
             />
           </div>{' '}
-          <div
-            className="font-pretendard text-xs font-normal sm:text-2xl sm:font-medium"
-          >
+          <div className="font-pretendard text-xs font-normal sm:text-2xl sm:font-medium">
             함께라면 더 밝은 미래로, 우리들의
           </div>
-          <div
-            className="font-pretendard mb-2 text-center text-sm font-bold tracking-widest sm:mt-[-4px] sm:text-[26px]"
-          >
+          <div className="font-pretendard mb-2 text-center text-sm font-bold tracking-widest sm:mt-[-4px] sm:text-[26px]">
             동문네트워크
           </div>
         </div>

--- a/src/fsd_entities/auth/api/index.ts
+++ b/src/fsd_entities/auth/api/index.ts
@@ -1,2 +1,3 @@
 export * from './post';
 export * from './get';
+export * from './post';

--- a/src/fsd_entities/auth/api/put.ts
+++ b/src/fsd_entities/auth/api/put.ts
@@ -1,0 +1,11 @@
+import { API } from '@/fsd_shared';
+
+const URI = '/api/v1/users';
+
+export const recoverAccount = async (
+  email: User.RecoverAccountRequestDto,
+): Promise<{ accessToken: string; refreshToken: string }> => {
+  const response = await API.put(`${URI}/recover`, email);
+
+  return response.data;
+};

--- a/src/fsd_entities/auth/model/hooks/index.ts
+++ b/src/fsd_entities/auth/model/hooks/index.ts
@@ -7,3 +7,4 @@ export * from './useAcademicRecordForm';
 export * from './useSignUpForm';
 export * from './useAdmissionForm';
 export * from './useVerification';
+export * from './useRecoverAccount';

--- a/src/fsd_entities/auth/model/hooks/useLogin.tsx
+++ b/src/fsd_entities/auth/model/hooks/useLogin.tsx
@@ -35,7 +35,6 @@ export const useLogin = ({ onDeletedAccount }: { onDeletedAccount?: () => void }
     },
     onError: (error: Error.ApiErrorResponse) => {
       if (axios.isAxiosError(error) && error.response?.data?.errorCode === 4103) {
-        console.log('Deleted account detected');
         onDeletedAccount?.();
         return;
       }

--- a/src/fsd_entities/auth/model/hooks/useLogin.tsx
+++ b/src/fsd_entities/auth/model/hooks/useLogin.tsx
@@ -19,18 +19,18 @@ export const useLogin = ({ onDeletedAccount }: { onDeletedAccount?: () => void }
       await setRscToken(accessToken, refreshToken);
       await setRccToken(accessToken, refreshToken);
 
-        const response = await getMyInfo();
-    
-        if (response.state === 'AWAIT') {
+      const response = await getMyInfo();
+
+      if (response.state === 'AWAIT') {
+        await router.push('/auth/authorization');
+      } else {
+        if (response.academicStatus == 'UNDETERMINED') {
           await router.push('/auth/authorization');
         } else {
-          if (response.academicStatus == 'UNDETERMINED') {
-            await router.push('/auth/authorization');
-          } else {
-            await router.push('/home');
-          }
+          await router.push('/home');
         }
       }
+
       toast.success('로그인 성공!');
     },
     onError: (error: Error.ApiErrorResponse) => {

--- a/src/fsd_entities/auth/model/hooks/useRecover.tsx
+++ b/src/fsd_entities/auth/model/hooks/useRecover.tsx
@@ -19,16 +19,15 @@ export const useLogin = ({ onDeletedAccount }: { onDeletedAccount?: () => void }
       await setRscToken(accessToken, refreshToken);
       await setRccToken(accessToken, refreshToken);
 
-        const response = await getMyInfo();
-    
-        if (response.state === 'AWAIT') {
-          await router.push('/auth/authorization');
+      const response = await getMyInfo();
+      console.log('response', response);
+      if (response.state === 'AWAIT') {
+        router.push('/auth/authorization');
+      } else {
+        if (response.academicStatus == 'UNDETERMINED') {
+          router.push('/auth/authorization');
         } else {
-          if (response.academicStatus == 'UNDETERMINED') {
-            await router.push('/auth/authorization');
-          } else {
-            await router.push('/home');
-          }
+          router.push('/home');
         }
       }
       toast.success('로그인 성공!');

--- a/src/fsd_shared/@types/user.d.ts
+++ b/src/fsd_shared/@types/user.d.ts
@@ -78,7 +78,9 @@ declare namespace User {
   }
 
   // ---
-
+  export interface RecoverAccountRequestDto {
+    email: string;
+  }
   export interface SignInRequestDto {
     email: string;
     password: string;

--- a/src/fsd_shared/ui/ActionModal.tsx
+++ b/src/fsd_shared/ui/ActionModal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+interface ActionModalProps {
+  closeModal: () => void;
+  children: React.ReactNode;
+  headTitle: string;
+  subTitle?: string;
+  topBtnLabel?: string;
+  BottomBtnLabel?: string;
+  topBtnOnClick?: () => void;
+  bottomBtnOnClick?: () => void;
+}
+
+export const ActionModal = ({
+  closeModal,
+  headTitle,
+  subTitle,
+  topBtnLabel,
+  BottomBtnLabel,
+  topBtnOnClick,
+  bottomBtnOnClick,
+}: ActionModalProps) => {
+  return (
+    <div className="fixed top-0 left-0 z-20 flex h-full w-full items-center justify-center bg-black/10">
+      <div className="relative flex w-[270px] flex-col items-center rounded-2xl border-1 border-[#F1F5F9] bg-white sm:w-[360px]">
+        <div className="flex w-full flex-col items-center gap-2 px-4 py-6">
+          <div className="text-[15px] font-semibold sm:text-xl">{headTitle}</div>
+          <div className="text-sm font-normal text-[#616464] sm:text-lg">{subTitle}</div>
+        </div>
+
+        <button
+          className="w-full border-y-1 border-y-[#F1F5F9] px-4 py-3 text-[15px] font-medium text-[#5D3EE7] sm:text-xl"
+          onClick={topBtnOnClick ?? closeModal}
+        >
+          {topBtnLabel ?? '취소'}
+        </button>
+        <button className="w-full px-4 py-3 text-[15px] font-semibold sm:text-xl" onClick={bottomBtnOnClick}>
+          {BottomBtnLabel ?? '확인'}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/fsd_shared/ui/ActionModal.tsx
+++ b/src/fsd_shared/ui/ActionModal.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 interface ActionModalProps {
   closeModal: () => void;
-  children: React.ReactNode;
   headTitle: string;
   subTitle?: string;
   topBtnLabel?: string;

--- a/src/fsd_shared/utils/axiosErrorParser.ts
+++ b/src/fsd_shared/utils/axiosErrorParser.ts
@@ -10,15 +10,17 @@ export const parseErrorMessage = (error: unknown, defaultMessage: string = '오�
   // Axios 에러인 경우
   if (axios.isAxiosError(error)) {
     const message = error.response?.data?.message;
+    console.error('Axios Error:', error);
     if (message) return message;
-    
+
     return error.message;
   }
-  
+
   // 일반 에러인 경우
   if (error instanceof Error) {
+    console.error('gen Error:', error);
     return error.message;
   }
-  
+
   return defaultMessage;
 };

--- a/src/fsd_shared/utils/axiosErrorParser.ts
+++ b/src/fsd_shared/utils/axiosErrorParser.ts
@@ -10,7 +10,6 @@ export const parseErrorMessage = (error: unknown, defaultMessage: string = '오�
   // Axios 에러인 경우
   if (axios.isAxiosError(error)) {
     const message = error.response?.data?.message;
-    console.error('Axios Error:', error);
     if (message) return message;
 
     return error.message;
@@ -18,7 +17,6 @@ export const parseErrorMessage = (error: unknown, defaultMessage: string = '오�
 
   // 일반 에러인 경우
   if (error instanceof Error) {
-    console.error('gen Error:', error);
     return error.message;
   }
 


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호

📋 PR Checklist

- 탈퇴한 회원이 로그인 시도 시 복구 확인 모달 띄우기
- 탈퇴한 계정 복구 api 연결
-

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
