### PR TITLE
[FIX]권한 별 설정페이지 경조사 메뉴 조정

### DIFF
--- a/src/app/(causw)/setting/page.tsx
+++ b/src/app/(causw)/setting/page.tsx
@@ -42,6 +42,7 @@ const SettingsPage = () => {
 
   const roles = userInfo.roles;
   const isPureGraduate = isGraduate(userInfo.academicStatus) && !isAlumniLeader(roles);
+  const isAdminGroup = isAdmin(roles) || isPresidents(roles) || isVicePresidents(roles);
 
   const circleIdIfLeader = userInfo.circleIdIfLeader;
   const circleNameIfLeader = userInfo.circleNameIfLeader;
@@ -172,7 +173,7 @@ const SettingsPage = () => {
         {/* 권한을 갖는 유저들에게 나타나는 UI */}
 
         {/* 학생 또는 졸업생인 경우 */}
-        {(isStudent(roles) || isPureGraduate) && (
+        {(isStudent(roles) || isPureGraduate) && !isAdminGroup && (
           <>
             <MenuItem title="경조사 관리" items={menuItems.occasionUserManagement} />
           </>
@@ -181,6 +182,7 @@ const SettingsPage = () => {
         {/* 교수인 경우 */}
 
         {/* 학생회에만 소속 */}
+        {/* 요청으로 인해 '권한 위임/관리' 주석처리(20250819) */}
         {/* {(isCouncil(roles) && !isCircleLeader(roles)) ||
           (isStudentLeader(roles) && !isCircleLeader(roles) && (
             <>
@@ -214,7 +216,7 @@ const SettingsPage = () => {
         )}
 
         {/* 관리자, 학생회장, 부학생회장 */}
-        {(isAdmin(roles) || isPresidents(roles) || isVicePresidents(roles)) && (
+        {isAdminGroup && (
           <>
             <MenuItem title="관리" items={menuItems.managementAdmin} />
             {/* <MenuItem title="권한 위임" items={menuItems.delegation} /> */}


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #286

📋 PR Checklist

- 관리자급 계정에는 설정 페이지에서 일반 경조사 박스/경조사 관리 박스 2가지 모두 보여서 수정했습니다.
- 관리자급 계정에는 설정 페이지에 경조사 관리가 있는 박스만 보이게 합니다.
- 외 계정에는 기본 경조사 관련 박스만
-
-

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
