### PR TITLE
설정 > 기록  메뉴 페이지들 카드 레이아웃 수정

### DIFF
--- a/src/entities/board/postList/PostItemStatusBar.tsx
+++ b/src/entities/board/postList/PostItemStatusBar.tsx
@@ -1,35 +1,46 @@
-import { Icon } from '@/fsd_shared';
+import clsx from 'clsx';
+import { MessageCircle, Star, ThumbsUp } from 'lucide-react';
+
+import { Divider } from '@/fsd_shared';
 import { getTimeDifference } from '@/utils/format';
+
+import FormIcon from '../../../../public/icons/form_icon.svg';
+import VoteIcon from '../../../../public/icons/vote_icon.svg';
 
 interface PostItemStatusBarProps {
   post: Post.PostResponseDto;
 }
-
+const totalCount = (count: number) => {
+  return count > 999 ? '999+' : count;
+};
 export const PostItemStatusBar = ({ post }: PostItemStatusBarProps) => {
   return (
-    <div className="flex divide-x-2">
+    <div className="flex items-center gap-2">
       <div className="flex gap-2 lg:gap-4">
-        <div className="flex items-center gap-1 sm:gap-2">
-          <Icon iconName="like" />
-          <p className="text-red-500">{post.numLike > 999 ? '999+' : post.numLike}</p>
+        <div className="flex items-center gap-1 text-red-500 sm:gap-2">
+          <ThumbsUp size={16} />
+          <p className="">{totalCount(post.numLike)}</p>
         </div>
-        <div className="hidden items-center gap-2 sm:flex">
-          <Icon iconName="scrap" />
-          <p className="text-yellow-500">{post.numFavorite > 999 ? '999+' : post.numFavorite}</p>
+        <div className="hidden items-center gap-1 text-yellow-500 sm:flex">
+          <Star size={16} />
+          <p>{totalCount(post.numFavorite)}</p>
         </div>
-        <div className="flex items-center gap-2 pr-2">
-          <Icon iconName="comment" />
-          <p className="text-blue-300">{post.numComment > 999 ? '999+' : post.numComment}</p>
+        <div className="flex items-center gap-1 text-blue-300 sm:gap-2">
+          <MessageCircle size={16} />
+          <p>{totalCount(post.numComment)}</p>
         </div>
       </div>
-      <div className="flex items-center gap-2 px-2">
-        <Icon iconName={post.isPostVote ? 'vote_active' : 'vote_inactive'} />
-        <Icon iconName={post.isPostForm ? 'apply_active' : 'apply_inactive'} />
+      <Divider vertical />
+      <div className="flex items-center gap-2">
+        <VoteIcon className={clsx(post.isPostVote ? 'text-[#FFC71B]' : 'text-[#B4B1B1]', 'h-4 w-4')} />
+        <FormIcon className={clsx(post.isPostForm ? 'text-[#FFC71B]' : 'text-[#B4B1B1]', 'h-4 w-4')} />
       </div>
-      <div className="sm:text-md flex items-center gap-2 px-2 text-center text-xs text-gray-300">
+      <Divider vertical />
+      <div className="sm:text-md flex items-center text-center text-xs text-gray-300">
         {getTimeDifference(post.createdAt)}
       </div>
-      <div className="sm:text-md flex items-center gap-2 px-2 text-center text-xs text-gray-300">
+      <Divider vertical />
+      <div className="sm:text-md flex items-center text-center text-xs text-gray-300">
         {post.displayWriterNickname ? post.displayWriterNickname : post.isAnonymous ? '익명' : post.writerNickname}
       </div>
     </div>

--- a/src/fsd_entities/post/ui/PostCard/PostCardStatusBar.tsx
+++ b/src/fsd_entities/post/ui/PostCard/PostCardStatusBar.tsx
@@ -42,7 +42,7 @@ export const PostCardStatusBar = ({ post }: PostCardStatusBarProps) => {
         {getTimeDifference(post.createdAt)}
       </div>
       <Divider vertical />
-      <div className="sm:text-md flex items-center pl-2 text-center text-xs text-gray-300 lg:pl-4">
+      <div className="sm:text-md flex items-center text-center text-xs text-gray-300">
         {post.displayWriterNickname ? post.displayWriterNickname : post.isAnonymous ? '익명' : post.writerNickname}
       </div>
     </div>

--- a/src/fsd_entities/user/ui/PersonalSettings/MyRecordList.tsx
+++ b/src/fsd_entities/user/ui/PersonalSettings/MyRecordList.tsx
@@ -48,7 +48,7 @@ export const MyRecordList = ({
   }
 
   return (
-    <div className="xs:px-5 mt-4 flex flex-1 flex-col gap-4 overflow-y-auto px-[5px] pb-4 pl-5">
+    <div className="flex w-full grow flex-col gap-4 overflow-y-auto px-1.5 pb-2">
       {postList?.length === 0 ? (
         <div className="flex h-full w-full items-center justify-center text-2xl">게시글이 없습니다.</div>
       ) : (


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호

📋 PR Checklist

-설정 > 기록 메뉴 페이지에서 카드 목록 padding값과 카드 안에 status bar들 레이아웃을 게시판과 동일하게 통일시켰습니다
-
-

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
