### PR TITLE
[FIX] 게시글 등록 시 사진 관련 이슈

### DIFF
--- a/src/fsd_entities/post/config/fileUploadRule.ts
+++ b/src/fsd_entities/post/config/fileUploadRule.ts
@@ -1,6 +1,6 @@
 export const FILE_UPLOAD_RULES = {
   MAX_FILE_SIZE: 10 * 1024 * 1024, // 10MB
-  MAX_FILE_COUNT: 10,
+  MAX_FILE_COUNT: 20,
   ALLOWED_EXTENSIONS: [
     'jpg',
     'jpeg',

--- a/src/fsd_entities/post/model/hooks/useUploadFile.ts
+++ b/src/fsd_entities/post/model/hooks/useUploadFile.ts
@@ -47,6 +47,11 @@ export const useUploadFile = () => {
 
     const filesArray = Array.from(files);
 
+    if (selectedFileList.length + filesArray.length > FILE_UPLOAD_RULES.MAX_FILE_COUNT) {
+      toast.error(`파일은 최대 ${FILE_UPLOAD_RULES.MAX_FILE_COUNT}개까지 업로드할 수 있습니다.`);
+      return;
+    }
+
     for (const file of filesArray) {
       if (file.size > FILE_UPLOAD_RULES.MAX_FILE_SIZE) {
         toast.error(`파일의 크기가 10MB를 초과합니다.`);

--- a/src/fsd_widgets/post/ui/PostCreationFormButtonGrorup/PostCreationFormButtonGroup.tsx
+++ b/src/fsd_widgets/post/ui/PostCreationFormButtonGrorup/PostCreationFormButtonGroup.tsx
@@ -40,6 +40,7 @@ export const PostCreationFormButtonGroup = ({ disabled }: PostCreationFormButton
         multiple
       />
       <button
+        type="button"
         className={`bg-comment-input flex w-16 items-center justify-center rounded-full md:w-20 md:p-3`}
         onClick={handleFileUploadButtonClick}
       >

--- a/src/fsd_widgets/post/ui/PostDetailSection/PostDetailSection.tsx
+++ b/src/fsd_widgets/post/ui/PostDetailSection/PostDetailSection.tsx
@@ -9,7 +9,6 @@ interface PostDetailSectionProps {
 }
 
 export const PostDetailSection = ({ postData }: PostDetailSectionProps) => {
-  console.log('postData:', postData);
   return (
     <section className="rounded-post-br bg-post shadow-post-sh relative flex max-w-xl flex-col border p-2">
       <PostActionDropdown

--- a/src/fsd_widgets/post/ui/PostDetailSection/PostDetailSection.tsx
+++ b/src/fsd_widgets/post/ui/PostDetailSection/PostDetailSection.tsx
@@ -9,6 +9,7 @@ interface PostDetailSectionProps {
 }
 
 export const PostDetailSection = ({ postData }: PostDetailSectionProps) => {
+  console.log('postData:', postData);
   return (
     <section className="rounded-post-br bg-post shadow-post-sh relative flex max-w-xl flex-col border p-2">
       <PostActionDropdown


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #327 

📋 PR Checklist

- 사진 등록 누르면 게시글이 등록 되버리는 이슈
- 사진 제한 10개 -> 20개 
- 사진 업로드할 때 20개 이상을 한꺼번에 선택해서 올리면 등록이 되는 이슈

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
