### PR TITLE
[FEAT] 회원가입: 입학년도 및 학과 선택 방식 개선 feat 새로운 기능, 코드 추가

### DIFF
--- a/src/entities/auth/config/signUpValidation.ts
+++ b/src/entities/auth/config/signUpValidation.ts
@@ -50,8 +50,8 @@ export const signUpValidationRules: Record<keyof User.SignUpForm, RegisterOption
       return !(await checkNicknameDuplicate(value)) || '이미 사용 중인 닉네임입니다.';
     },
   },
-  major: {
-    required: '학과를 입력해주세요.',
+  department: {
+    required: '학과/학부를 입력해주세요.',
   },
   agreeToTerms: {
     required: '약관에 동의해주세요.',

--- a/src/entities/auth/model/hooks/useSignUpForm.ts
+++ b/src/entities/auth/model/hooks/useSignUpForm.ts
@@ -9,7 +9,7 @@ const allowedKeys = [
   'password',
   'studentId',
   'name',
-  'major',
+  'department',
   'phoneNumber',
   'admissionYear',
 ] as const;

--- a/src/shared/@types/user.d.ts
+++ b/src/shared/@types/user.d.ts
@@ -153,7 +153,7 @@ declare namespace User {
     studentId?: string;
     admissionYearString: string;
     nickname: string;
-    major: string;
+    department: string;
     agreeToTerms: boolean;
     agreeToPopup: boolean;
     phoneNumber: string;
@@ -166,7 +166,7 @@ declare namespace User {
     studentId?: string;
     admissionYear: number;
     nickname: string;
-    major: string;
+    department: string;
     phoneNumber: string;
   }
 

--- a/src/widgets/auth/ui/SignUpFormFields.tsx
+++ b/src/widgets/auth/ui/SignUpFormFields.tsx
@@ -1,6 +1,7 @@
 import { FieldErrors, UseFormRegister, UseFormWatch } from 'react-hook-form';
 
 import { AuthInput, SignUpCheckbox, SignUpSelect, signUpValidationRules } from '@/entities/auth';
+
 import { formatPhoneNumber } from '@/shared';
 
 interface Props {
@@ -11,10 +12,12 @@ interface Props {
 
 export const SignUpFormFields = ({ register, errors, watch }: Props) => {
   const password = watch('password');
+  const admissionYear = watch('admissionYearString');
+  const isNewMajorSystem = admissionYear && parseInt(admissionYear, 10) >= 2021;
 
   return (
     <>
-      <div className="grid w-full max-w-3xl grid-cols-1 place-items-center gap-y-2 gap-x-8 lg:p-8 lg:grid lg:grid-cols-2">
+      <div className="grid w-full max-w-3xl grid-cols-1 place-items-center gap-x-8 gap-y-2 lg:grid lg:grid-cols-2 lg:p-8">
         <AuthInput
           register={register}
           name="email"
@@ -52,7 +55,7 @@ export const SignUpFormFields = ({ register, errors, watch }: Props) => {
           placeholder="8자리 이상, 영어/숫자/특수 문자"
           errorMessage={errors.pwConfirm?.message}
         />
-                <SignUpSelect
+        <SignUpSelect
           register={register}
           name="admissionYearString"
           label="입학년도"
@@ -71,7 +74,6 @@ export const SignUpFormFields = ({ register, errors, watch }: Props) => {
           placeholder="학번 8자리를 입력해주세요 (선택사항)"
           errorMessage={errors.studentId?.message}
         />
-
         <AuthInput
           register={register}
           name="name"
@@ -80,14 +82,21 @@ export const SignUpFormFields = ({ register, errors, watch }: Props) => {
           placeholder="이름을 입력해주세요"
           errorMessage={errors.name?.message}
         />
-        <AuthInput
-          register={register}
-          name="major"
-          rules={signUpValidationRules.major}
-          label="학부/학과"
-          placeholder="ex) 소프트웨어학부, 컴퓨터공학부"
-          errorMessage={errors.major?.message}
-        />
+        {isNewMajorSystem ? (
+          <SignUpSelect
+            register={register}
+            name="department"
+            label="학과"
+            rules={signUpValidationRules.department}
+            errorMessage={errors.department?.message}
+            options={[
+              { value: 'DEPT_OF_AI', label: 'AI학과' },
+              { value: 'SCHOOL_OF_SW', label: '소프트웨어학부' },
+            ]}
+          />
+        ) : (
+          <div></div>
+        )}
         <AuthInput
           register={register}
           name="phoneNumber"


### PR DESCRIPTION
🚩 관련 이슈
#351 

📋 PR Checklist
- 회원가입에서 입학 년도 21년도부터는 학과(AI/소프트)를 Select로 선택할 수 있도록 변경
- 입학 년도 20년도 이전은 학과 선택 없음 → 학과 null로 전송 (서버에서 학과 null일 경우, 해당 년도에 맞는 학과로 자동 부여)

📌 유의사항
✅ 테스트 결과

https://github.com/user-attachments/assets/0c58a0a8-4aa8-4fa8-ba62-54f14ab826a2

