### PR TITLE
[FIX] 게시판 이름 1줄로 통일 및 말줄임표 설정

### DIFF
--- a/src/entities/board/ui/BoardList/Board.tsx
+++ b/src/entities/board/ui/BoardList/Board.tsx
@@ -76,9 +76,9 @@ export const Board = ({ boardId, boardName, contents }: Board.BoardResponseDto) 
           href={`/board/${boardId}`}
           className="group flex items-center justify-between border-b-2 border-gray-200 pb-2"
         >
-          <div className="flex items-center gap-2">
+          <div className="flex w-full items-center gap-2">
             <div className="h-9 w-9">{style.icon}</div>
-            <h2 className={`text-2xl font-semibold text-gray-700 ${underlineStyles}`}>{boardName}</h2>
+            <h2 className={`truncate text-2xl font-semibold text-gray-700 ${underlineStyles}`}>{boardName}</h2>
           </div>
           <ChevronRight className="h-4 w-4 text-gray-400 transition-transform duration-200 group-hover:translate-x-0.5 lg:h-6 lg:w-6" />
         </Link>


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #370 

📋 PR Checklist

- 게시판 이름 1줄로 통일 및 말줄임표 설정
-
-

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
<img width="383" height="816" alt="image" src="https://github.com/user-attachments/assets/84cca620-ced5-41be-8155-1b143e9f0004" /> <img width="389" height="823" alt="image" src="https://github.com/user-attachments/assets/11d8f228-aae6-4cb6-8701-0f8a75dfbb0d" />
