### PR TITLE
[CHORE] 질문 글 여부 칼럼 조회해서 ui 표시하도록 수정

### DIFF
--- a/src/entities/board/ui/BoardList/Board.tsx
+++ b/src/entities/board/ui/BoardList/Board.tsx
@@ -119,6 +119,7 @@ export const Board = ({
                 title={content.title}
               >
                 <span className="block w-full truncate text-xl font-medium">
+                  {content.isQuestion ? '[질문] ' : ''}
                   {content.title}
                 </span>
                 <div className="text-base text-gray-400">

--- a/src/entities/post/ui/PostCard/PostCard.tsx
+++ b/src/entities/post/ui/PostCard/PostCard.tsx
@@ -26,6 +26,7 @@ export const PostCard = ({ post, targetUrl }: PostCardProps) => {
       <div className="grid h-full w-full grid-rows-[1fr_1.5rem]">
         <div className="flex h-15 w-full justify-between gap-[22px] md:h-[85px] md:gap-[30px]">
           <p className="line-clamp-2 h-14 text-xl font-bold md:h-20 md:text-[32px]">
+            {post.isQuestion ? '[질문] ' : ''}
             {post.title}
           </p>
           <div className="h-15 w-15 shrink-0 overflow-hidden rounded-lg sm:h-30 sm:w-30">

--- a/src/shared/@types/board.d.ts
+++ b/src/shared/@types/board.d.ts
@@ -34,6 +34,7 @@ declare namespace Board {
     displayWriterNickname: string;
     createdAt: string;
     isAnonymous: boolean;
+    isQuestion: boolean;
   }
   export interface CreateBoardDto {
     boardName: string;


### PR DESCRIPTION
🚩 관련 이슈
ex) resolve #이슈번호

📋 PR Checklist

- 게시글에서 질문 글일 경우 [질문] 태그 ui 상으로 표시했습니다.
- 게시판 리스트에서도 서버단에서 반영될 것으로 예상해서 같이 처리해뒀습니다

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
