### PR TITLE
fix: #392 모바일 CeremonySectionTitle 텍스트 잘림 현상 해결

### DIFF
--- a/src/entities/ceremony/ui/AdminCeremonySectionTitle.tsx
+++ b/src/entities/ceremony/ui/AdminCeremonySectionTitle.tsx
@@ -11,10 +11,10 @@ export const CeremonySectionTitle = ({
       className={clsx(
         title === MESSAGES.CEREMONY.DETAIL_CONTENTS
           ? 'flex flex-col gap-y-2'
-          : 'flex flex-col gap-y-2 md:grid md:grid-cols-[auto_1fr] md:gap-x-2',
+          : 'grid grid-cols-[auto_1fr] gap-x-2 md:block md:gap-y-2',
       )}
     >
-      <h1 className="text-lg font-semibold md:min-w-[120px] md:text-2xl">
+      <h1 className="min-w-[120px] text-lg font-semibold md:text-2xl">
         {title}
       </h1>
 


### PR DESCRIPTION
🚩 관련 이슈
#392 

📋 PR Checklist

-
-
-

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브
